### PR TITLE
Add Storybook color asset list for style variables

### DIFF
--- a/src/stories/lib/style/variable.stories.tsx
+++ b/src/stories/lib/style/variable.stories.tsx
@@ -9,8 +9,8 @@ const ColorAssetList = () => {
     <div
       style={{
         display: "grid",
-        gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))",
-        gap: "16px",
+        gridTemplateColumns: "repeat(auto-fill, minmax(120px, 1fr))",
+        gap: "10px",
         width: "min(100%, 960px)",
       }}
     >
@@ -46,21 +46,17 @@ const ColorAssetList = () => {
               style={{
                 backgroundColor: color,
                 color: textColor,
-                minHeight: "92px",
+                minHeight: "60px",
                 padding: "12px",
                 display: "flex",
                 alignItems: "flex-end",
                 fontWeight: 700,
               }}
-            >
-              {name}
-            </div>
+            ></div>
 
-            <div style={{ padding: "10px 12px 12px" }}>
-              <div style={{ color: "#6b7280", fontSize: "12px", marginBottom: "4px" }}>Token</div>
-              <code style={{ fontSize: "13px", fontWeight: 600 }}>{name}</code>
-              <div style={{ color: "#6b7280", fontSize: "12px", margin: "10px 0 4px" }}>Value</div>
-              <code style={{ fontSize: "13px", fontWeight: 600 }}>{color}</code>
+            <div style={{ padding: "5px 10px", borderTop: "1px solid #e5e7eb" }}>
+              <div style={{ fontSize: "16px", fontWeight: "bold", color: "#2196f3" }}>{name}</div>
+              <div style={{ fontSize: "13px", fontWeight: 400 }}>{color}</div>
             </div>
           </div>
         );
@@ -76,7 +72,8 @@ const meta = {
     layout: "padded",
     docs: {
       description: {
-        component: "`src/lib/style/_variable.ts` の `params` で定義されているカラーアセット一覧です。",
+        component:
+          "`src/lib/style/_variable.ts` の `params` で定義されているカラーアセット一覧です。",
       },
     },
   },
@@ -87,6 +84,4 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Colors: Story = {
-  render: () => <ColorAssetList />,
-};
+export const Colors: Story = { render: () => <ColorAssetList /> };

--- a/src/stories/lib/style/variable.stories.tsx
+++ b/src/stories/lib/style/variable.stories.tsx
@@ -1,0 +1,92 @@
+import { params } from "../../../lib/style";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+const ColorAssetList = () => {
+  const colorEntries = Object.entries(params);
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))",
+        gap: "16px",
+        width: "min(100%, 960px)",
+      }}
+    >
+      {colorEntries.map(([name, color]) => {
+        const normalized = color.replace("#", "");
+        const hasValidHex = normalized.length === 3 || normalized.length === 6;
+
+        const expanded =
+          hasValidHex && normalized.length === 3
+            ? normalized
+                .split("")
+                .map((char) => `${char}${char}`)
+                .join("")
+            : normalized;
+
+        const red = Number.parseInt(expanded.slice(0, 2), 16);
+        const green = Number.parseInt(expanded.slice(2, 4), 16);
+        const blue = Number.parseInt(expanded.slice(4, 6), 16);
+        const luminance = (red * 299 + green * 587 + blue * 114) / 1000;
+        const textColor = luminance >= 140 ? "#1f2937" : "#ffffff";
+
+        return (
+          <div
+            key={name}
+            style={{
+              border: "1px solid #e5e7eb",
+              borderRadius: "10px",
+              overflow: "hidden",
+              backgroundColor: "#ffffff",
+            }}
+          >
+            <div
+              style={{
+                backgroundColor: color,
+                color: textColor,
+                minHeight: "92px",
+                padding: "12px",
+                display: "flex",
+                alignItems: "flex-end",
+                fontWeight: 700,
+              }}
+            >
+              {name}
+            </div>
+
+            <div style={{ padding: "10px 12px 12px" }}>
+              <div style={{ color: "#6b7280", fontSize: "12px", marginBottom: "4px" }}>Token</div>
+              <code style={{ fontSize: "13px", fontWeight: 600 }}>{name}</code>
+              <div style={{ color: "#6b7280", fontSize: "12px", margin: "10px 0 4px" }}>Value</div>
+              <code style={{ fontSize: "13px", fontWeight: 600 }}>{color}</code>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+const meta = {
+  title: "Lib/Style/Variable",
+  component: ColorAssetList,
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component: "`src/lib/style/_variable.ts` の `params` で定義されているカラーアセット一覧です。",
+      },
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof ColorAssetList>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Colors: Story = {
+  render: () => <ColorAssetList />,
+};


### PR DESCRIPTION
### Motivation
- Provide a Storybook page that visualizes the color tokens defined in `src/lib/style/_variable.ts` (`params`) for easier inspection and design review. 
- Follow the existing Storybook pattern (color asset listing) so designers and developers can quickly reference token names and values. 
- Use the repository-safe import surface (`src/lib/style/index.ts`) to avoid restricted imports of underscore-prefixed files. 

### Description
- Add `src/stories/lib/style/variable.stories.tsx` which renders a responsive grid of color cards enumerating `params` from `src/lib/style`. 
- Each card displays a color swatch, the token name and token value, and computes luminance to pick an accessible text color on the swatch. 
- Include Storybook metadata (`title`, `parameters.layout`, docs `description`) and export a `Colors` story that renders the list. 
- Import `params` via `../../../lib/style` (the project index export) to satisfy the repository's restricted-import rule. 

### Testing
- Ran `npx eslint src/stories/lib/style/variable.stories.tsx` after the import adjustment and it passed. 
- Ran `npm run lint` (which runs `eslint` + `tsc --noEmit`) and it completed successfully. 
- Running `npm run lint -- --max-warnings=0` failed due to `tsc` receiving `--max-warnings=0` and producing `TS5023`, which is unrelated to the story changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3e7b0da7c8324b4336029ce0a8a89)