### PR TITLE
feat: per-page SEO metadata (PageMeta) and apply to pages

### DIFF
--- a/src/components/layouts/layout.tsx
+++ b/src/components/layouts/layout.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import { Footer } from "./footer";
 import { Header } from "./header";
 import { Loading } from "./loading";
+import PageMeta from "../seo/pageMeta";
 
 import type { TypeLayout, TypeSelectorState } from "../../lib/types";
 import type React from "react";
@@ -13,13 +14,15 @@ import type React from "react";
  * ----------------------------------------------- */
 
 export const Layout: React.FC<TypeLayout> = (props) => {
-  const { type, children } = props;
+  const { type, meta, children } = props;
 
   // ローディングフラグ
   const loadingFlagCount = useSelector((state: TypeSelectorState) => state.loadingFlagCount);
 
   return (
     <Styled>
+      <PageMeta {...meta} />
+
       {/* 共通ローディング */}
       <Loading visible={loadingFlagCount > 0} />
 

--- a/src/components/layouts/layout.tsx
+++ b/src/components/layouts/layout.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { Footer } from "./footer";
 import { Header } from "./header";
 import { Loading } from "./loading";
-import PageMeta from "../seo/pageMeta";
+import PageMeta from "./pageMeta";
 
 import type { TypeLayout, TypeSelectorState } from "../../lib/types";
 import type React from "react";

--- a/src/components/layouts/pageMeta.tsx
+++ b/src/components/layouts/pageMeta.tsx
@@ -27,8 +27,9 @@ const PageMeta: React.FC<TypePageMetaProps> = ({
     const normalizedTitle = title?.trim() ? title.trim() : DEFAULT_TITLE;
     const normalizedDescription = description?.trim() ? description.trim() : DEFAULT_DESCRIPTION;
     const normalizedOgImage = ogImage?.trim() ? ogImage.trim() : DEFAULT_OG_IMAGE;
-    const fullTitle = normalizedTitle === DEFAULT_TITLE ? DEFAULT_TITLE : `${normalizedTitle} | ${SITE_NAME}`;
-    const url = window.location.href;
+    const fullTitle =
+      normalizedTitle === DEFAULT_TITLE ? DEFAULT_TITLE : `${normalizedTitle} | ${SITE_NAME}`;
+    const url = globalThis.location.href;
     const ogImageUrl = normalizedOgImage.startsWith("http")
       ? normalizedOgImage
       : `${BASE_URL}${normalizedOgImage}`;
@@ -36,11 +37,7 @@ const PageMeta: React.FC<TypePageMetaProps> = ({
 
     document.title = fullTitle;
 
-    const upsertMeta = (
-      key: "name" | "property",
-      value: string,
-      content: string,
-    ) => {
+    const upsertMeta = (key: "name" | "property", value: string, content: string) => {
       let tag = document.head.querySelector(`meta[${key}="${value}"]`);
 
       if (!tag) {

--- a/src/components/seo/pageMeta.tsx
+++ b/src/components/seo/pageMeta.tsx
@@ -1,0 +1,63 @@
+import { useEffect } from "react";
+
+import type React from "react";
+
+type TypePageMetaProps = {
+  title: string;
+  description: string;
+  ogImage: string;
+  ogType?: "website" | "article";
+  shareText?: string;
+};
+
+const SITE_NAME = "React Cognito Practice";
+const BASE_URL = "https://example.com";
+
+const PageMeta: React.FC<TypePageMetaProps> = ({
+  title,
+  description,
+  ogImage,
+  ogType = "website",
+  shareText,
+}) => {
+  useEffect(() => {
+    const fullTitle = `${title} | ${SITE_NAME}`;
+    const url = window.location.href;
+    const ogImageUrl = ogImage.startsWith("http") ? ogImage : `${BASE_URL}${ogImage}`;
+    const socialDescription = shareText ?? description;
+
+    document.title = fullTitle;
+
+    const upsertMeta = (
+      key: "name" | "property",
+      value: string,
+      content: string,
+    ) => {
+      let tag = document.head.querySelector(`meta[${key}="${value}"]`);
+
+      if (!tag) {
+        tag = document.createElement("meta");
+        tag.setAttribute(key, value);
+        document.head.appendChild(tag);
+      }
+
+      tag.setAttribute("content", content);
+    };
+
+    upsertMeta("name", "description", description);
+    upsertMeta("property", "og:title", fullTitle);
+    upsertMeta("property", "og:description", socialDescription);
+    upsertMeta("property", "og:type", ogType);
+    upsertMeta("property", "og:url", url);
+    upsertMeta("property", "og:site_name", SITE_NAME);
+    upsertMeta("property", "og:image", ogImageUrl);
+    upsertMeta("name", "twitter:card", "summary_large_image");
+    upsertMeta("name", "twitter:title", fullTitle);
+    upsertMeta("name", "twitter:description", socialDescription);
+    upsertMeta("name", "twitter:image", ogImageUrl);
+  }, [description, ogImage, ogType, shareText, title]);
+
+  return null;
+};
+
+export default PageMeta;

--- a/src/components/seo/pageMeta.tsx
+++ b/src/components/seo/pageMeta.tsx
@@ -2,16 +2,19 @@ import { useEffect } from "react";
 
 import type React from "react";
 
-type TypePageMetaProps = {
-  title: string;
-  description: string;
-  ogImage: string;
+export type TypePageMetaProps = {
+  title?: string;
+  description?: string;
+  ogImage?: string;
   ogType?: "website" | "article";
   shareText?: string;
 };
 
 const SITE_NAME = "React Cognito Practice";
 const BASE_URL = "https://example.com";
+const DEFAULT_TITLE = "React Cognito Practice";
+const DEFAULT_DESCRIPTION = "React と Cognito の検証用サンプルアプリです。";
+const DEFAULT_OG_IMAGE = "/vite.svg";
 
 const PageMeta: React.FC<TypePageMetaProps> = ({
   title,
@@ -21,10 +24,15 @@ const PageMeta: React.FC<TypePageMetaProps> = ({
   shareText,
 }) => {
   useEffect(() => {
-    const fullTitle = `${title} | ${SITE_NAME}`;
+    const normalizedTitle = title?.trim() ? title.trim() : DEFAULT_TITLE;
+    const normalizedDescription = description?.trim() ? description.trim() : DEFAULT_DESCRIPTION;
+    const normalizedOgImage = ogImage?.trim() ? ogImage.trim() : DEFAULT_OG_IMAGE;
+    const fullTitle = normalizedTitle === DEFAULT_TITLE ? DEFAULT_TITLE : `${normalizedTitle} | ${SITE_NAME}`;
     const url = window.location.href;
-    const ogImageUrl = ogImage.startsWith("http") ? ogImage : `${BASE_URL}${ogImage}`;
-    const socialDescription = shareText ?? description;
+    const ogImageUrl = normalizedOgImage.startsWith("http")
+      ? normalizedOgImage
+      : `${BASE_URL}${normalizedOgImage}`;
+    const socialDescription = shareText?.trim() ? shareText.trim() : normalizedDescription;
 
     document.title = fullTitle;
 
@@ -44,7 +52,7 @@ const PageMeta: React.FC<TypePageMetaProps> = ({
       tag.setAttribute("content", content);
     };
 
-    upsertMeta("name", "description", description);
+    upsertMeta("name", "description", normalizedDescription);
     upsertMeta("property", "og:title", fullTitle);
     upsertMeta("property", "og:description", socialDescription);
     upsertMeta("property", "og:type", ogType);

--- a/src/features/auth/signIn/page.tsx
+++ b/src/features/auth/signIn/page.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import Button from "../../../components/button/button";
 import Input from "../../../components/form/input";
 import Layout from "../../../components/layouts/layout";
+import PageMeta from "../../../components/seo/pageMeta";
 import { signInHelper, useAuth } from "../../../utils/authHelper";
 
 import type { TypeSignInValues } from "../../../lib/types";
@@ -30,9 +31,16 @@ const SignIn: React.FC = () => {
   });
 
   return (
-    <Layout type="auth">
-      <Styled>
-        <h1>SignIn</h1>
+    <>
+      <PageMeta
+        description="メールアドレスとパスワードでログインするページです。"
+        ogImage="/vite.svg"
+        shareText="React Cognito Practice のサインインページです。"
+        title="Sign In"
+      />
+      <Layout type="auth">
+        <Styled>
+          <h1>SignIn</h1>
 
         {/* インプット項目 - E-mail */}
         <Input
@@ -61,8 +69,9 @@ const SignIn: React.FC = () => {
           </Button>
           <Button onClick={() => onSubmit()}>送信する</Button>
         </div>
-      </Styled>
-    </Layout>
+        </Styled>
+      </Layout>
+    </>
   );
 };
 

--- a/src/features/auth/signIn/page.tsx
+++ b/src/features/auth/signIn/page.tsx
@@ -4,7 +4,6 @@ import styled from "styled-components";
 import Button from "../../../components/button/button";
 import Input from "../../../components/form/input";
 import Layout from "../../../components/layouts/layout";
-import PageMeta from "../../../components/seo/pageMeta";
 import { signInHelper, useAuth } from "../../../utils/authHelper";
 
 import type { TypeSignInValues } from "../../../lib/types";
@@ -31,16 +30,17 @@ const SignIn: React.FC = () => {
   });
 
   return (
-    <>
-      <PageMeta
-        description="メールアドレスとパスワードでログインするページです。"
-        ogImage="/vite.svg"
-        shareText="React Cognito Practice のサインインページです。"
-        title="Sign In"
-      />
-      <Layout type="auth">
-        <Styled>
-          <h1>SignIn</h1>
+    <Layout
+      meta={{
+        title: "Sign In",
+        description: "メールアドレスとパスワードでログインするページです。",
+        ogImage: "/vite.svg",
+        shareText: "React Cognito Practice のサインインページです。",
+      }}
+      type="auth"
+    >
+      <Styled>
+        <h1>SignIn</h1>
 
         {/* インプット項目 - E-mail */}
         <Input
@@ -69,9 +69,8 @@ const SignIn: React.FC = () => {
           </Button>
           <Button onClick={() => onSubmit()}>送信する</Button>
         </div>
-        </Styled>
-      </Layout>
-    </>
+      </Styled>
+    </Layout>
   );
 };
 

--- a/src/features/auth/signOut/page.tsx
+++ b/src/features/auth/signOut/page.tsx
@@ -2,7 +2,6 @@ import styled from "styled-components";
 
 import Button from "../../../components/button/button";
 import Layout from "../../../components/layouts/layout";
-import PageMeta from "../../../components/seo/pageMeta";
 import { signOutHelper, useAuth } from "../../../utils/authHelper";
 
 import type React from "react";
@@ -23,24 +22,24 @@ const SignOut: React.FC = () => {
   };
 
   return (
-    <>
-      <PageMeta
-        description="現在のセッションからサインアウトするページです。"
-        ogImage="/vite.svg"
-        shareText="React Cognito Practice のサインアウトページです。"
-        title="Sign Out"
-      />
-      <Layout type="auth">
-        <Styled>
-          <h1>サインアウト</h1>
+    <Layout
+      meta={{
+        title: "Sign Out",
+        description: "現在のセッションからサインアウトするページです。",
+        ogImage: "/vite.svg",
+        shareText: "React Cognito Practice のサインアウトページです。",
+      }}
+      type="auth"
+    >
+      <Styled>
+        <h1>サインアウト</h1>
 
         {/* ボタン */}
         <div className="mt-30">
           <Button onClick={signOut}>Sign Out</Button>
         </div>
-        </Styled>
-      </Layout>
-    </>
+      </Styled>
+    </Layout>
   );
 };
 

--- a/src/features/auth/signOut/page.tsx
+++ b/src/features/auth/signOut/page.tsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 
 import Button from "../../../components/button/button";
 import Layout from "../../../components/layouts/layout";
+import PageMeta from "../../../components/seo/pageMeta";
 import { signOutHelper, useAuth } from "../../../utils/authHelper";
 
 import type React from "react";
@@ -22,16 +23,24 @@ const SignOut: React.FC = () => {
   };
 
   return (
-    <Layout type="auth">
-      <Styled>
-        <h1>サインアウト</h1>
+    <>
+      <PageMeta
+        description="現在のセッションからサインアウトするページです。"
+        ogImage="/vite.svg"
+        shareText="React Cognito Practice のサインアウトページです。"
+        title="Sign Out"
+      />
+      <Layout type="auth">
+        <Styled>
+          <h1>サインアウト</h1>
 
         {/* ボタン */}
         <div className="mt-30">
           <Button onClick={signOut}>Sign Out</Button>
         </div>
-      </Styled>
-    </Layout>
+        </Styled>
+      </Layout>
+    </>
   );
 };
 

--- a/src/features/auth/signUp/page.tsx
+++ b/src/features/auth/signUp/page.tsx
@@ -4,7 +4,6 @@ import styled from "styled-components";
 import Button from "../../../components/button/button";
 import Input from "../../../components/form/input";
 import Layout from "../../../components/layouts/layout";
-import PageMeta from "../../../components/seo/pageMeta";
 import { signUpHelper } from "../../../utils/authHelper";
 
 import type { TypeSignUpValues } from "../../../lib/types";
@@ -28,17 +27,18 @@ const SignUp: React.FC = () => {
   });
 
   return (
-    <>
-      <PageMeta
-        description="メールアドレスとパスワードでアカウントを作成するページです。"
-        ogImage="/vite.svg"
-        shareText="React Cognito Practice のサインアップページです。"
-        title="Sign Up"
-      />
-      <Layout type="auth">
-        <Styled>
-          <form>
-            <h1>SignUp</h1>
+    <Layout
+      meta={{
+        title: "Sign Up",
+        description: "メールアドレスとパスワードでアカウントを作成するページです。",
+        ogImage: "/vite.svg",
+        shareText: "React Cognito Practice のサインアップページです。",
+      }}
+      type="auth"
+    >
+      <Styled>
+        <form>
+          <h1>SignUp</h1>
 
           {/* インプット項目 - E-mail */}
           <Input
@@ -67,10 +67,9 @@ const SignUp: React.FC = () => {
             </Button>
             <Button onClick={() => onSubmit()}>送信する</Button>
           </div>
-          </form>
-        </Styled>
-      </Layout>
-    </>
+        </form>
+      </Styled>
+    </Layout>
   );
 };
 

--- a/src/features/auth/signUp/page.tsx
+++ b/src/features/auth/signUp/page.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import Button from "../../../components/button/button";
 import Input from "../../../components/form/input";
 import Layout from "../../../components/layouts/layout";
+import PageMeta from "../../../components/seo/pageMeta";
 import { signUpHelper } from "../../../utils/authHelper";
 
 import type { TypeSignUpValues } from "../../../lib/types";
@@ -27,10 +28,17 @@ const SignUp: React.FC = () => {
   });
 
   return (
-    <Layout type="auth">
-      <Styled>
-        <form>
-          <h1>SignUp</h1>
+    <>
+      <PageMeta
+        description="メールアドレスとパスワードでアカウントを作成するページです。"
+        ogImage="/vite.svg"
+        shareText="React Cognito Practice のサインアップページです。"
+        title="Sign Up"
+      />
+      <Layout type="auth">
+        <Styled>
+          <form>
+            <h1>SignUp</h1>
 
           {/* インプット項目 - E-mail */}
           <Input
@@ -59,9 +67,10 @@ const SignUp: React.FC = () => {
             </Button>
             <Button onClick={() => onSubmit()}>送信する</Button>
           </div>
-        </form>
-      </Styled>
-    </Layout>
+          </form>
+        </Styled>
+      </Layout>
+    </>
   );
 };
 

--- a/src/features/auth/verification/page.tsx
+++ b/src/features/auth/verification/page.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import Button from "../../../components/button/button";
 import Input from "../../../components/form/input";
 import Layout from "../../../components/layouts/layout";
+import PageMeta from "../../../components/seo/pageMeta";
 import { verifyHelper } from "../../../utils/authHelper";
 
 import type { TypeVerifyValues } from "../../../lib/types";
@@ -29,9 +30,16 @@ const Verification: React.FC = () => {
   });
 
   return (
-    <Layout type="auth">
-      <Styled>
-        <h1>Verification</h1>
+    <>
+      <PageMeta
+        description="確認コードを入力してアカウント認証を完了するページです。"
+        ogImage="/vite.svg"
+        shareText="React Cognito Practice の認証ページです。"
+        title="Verification"
+      />
+      <Layout type="auth">
+        <Styled>
+          <h1>Verification</h1>
 
         {/* インプット項目 - password（verificationCode） */}
         <Input
@@ -60,8 +68,9 @@ const Verification: React.FC = () => {
           </Button>
           <Button onClick={() => onSubmit()}>送信する</Button>
         </div>
-      </Styled>
-    </Layout>
+        </Styled>
+      </Layout>
+    </>
   );
 };
 

--- a/src/features/auth/verification/page.tsx
+++ b/src/features/auth/verification/page.tsx
@@ -4,7 +4,6 @@ import styled from "styled-components";
 import Button from "../../../components/button/button";
 import Input from "../../../components/form/input";
 import Layout from "../../../components/layouts/layout";
-import PageMeta from "../../../components/seo/pageMeta";
 import { verifyHelper } from "../../../utils/authHelper";
 
 import type { TypeVerifyValues } from "../../../lib/types";
@@ -30,16 +29,17 @@ const Verification: React.FC = () => {
   });
 
   return (
-    <>
-      <PageMeta
-        description="確認コードを入力してアカウント認証を完了するページです。"
-        ogImage="/vite.svg"
-        shareText="React Cognito Practice の認証ページです。"
-        title="Verification"
-      />
-      <Layout type="auth">
-        <Styled>
-          <h1>Verification</h1>
+    <Layout
+      meta={{
+        title: "Verification",
+        description: "確認コードを入力してアカウント認証を完了するページです。",
+        ogImage: "/vite.svg",
+        shareText: "React Cognito Practice の認証ページです。",
+      }}
+      type="auth"
+    >
+      <Styled>
+        <h1>Verification</h1>
 
         {/* インプット項目 - password（verificationCode） */}
         <Input
@@ -68,9 +68,8 @@ const Verification: React.FC = () => {
           </Button>
           <Button onClick={() => onSubmit()}>送信する</Button>
         </div>
-        </Styled>
-      </Layout>
-    </>
+      </Styled>
+    </Layout>
   );
 };
 

--- a/src/features/example/accordionExample/page.tsx
+++ b/src/features/example/accordionExample/page.tsx
@@ -2,7 +2,6 @@ import styled from "styled-components";
 
 import Accordion from "../../../components/accordion/accordion";
 import Layout from "../../../components/layouts/layout";
-import PageMeta from "../../../components/seo/pageMeta";
 import { color, media } from "../../../lib/style";
 
 import type React from "react";
@@ -13,18 +12,19 @@ import type React from "react";
 
 const AccordionExample: React.FC = () => {
   return (
-    <>
-      <PageMeta
-        description="アコーディオンコンポーネントの利用例を確認できるサンプルページです。"
-        ogImage="/vite.svg"
-        shareText="アコーディオン UI サンプルページです。"
-        title="Accordion Example"
-      />
-      <Layout type="example">
-        <Styled>
-          <h1>
-            <span>AccordionExample</span>
-          </h1>
+    <Layout
+      meta={{
+        title: "Accordion Example",
+        description: "アコーディオンコンポーネントの利用例を確認できるサンプルページです。",
+        ogImage: "/vite.svg",
+        shareText: "アコーディオン UI サンプルページです。",
+      }}
+      type="example"
+    >
+      <Styled>
+        <h1>
+          <span>AccordionExample</span>
+        </h1>
 
         {/* アコーディオン */}
         <Accordion className="mt-30" title="アコーディオンタイトル">
@@ -49,9 +49,8 @@ const AccordionExample: React.FC = () => {
             ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・
           </p>
         </Accordion>
-        </Styled>
-      </Layout>
-    </>
+      </Styled>
+    </Layout>
   );
 };
 

--- a/src/features/example/accordionExample/page.tsx
+++ b/src/features/example/accordionExample/page.tsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 
 import Accordion from "../../../components/accordion/accordion";
 import Layout from "../../../components/layouts/layout";
+import PageMeta from "../../../components/seo/pageMeta";
 import { color, media } from "../../../lib/style";
 
 import type React from "react";
@@ -12,11 +13,18 @@ import type React from "react";
 
 const AccordionExample: React.FC = () => {
   return (
-    <Layout type="example">
-      <Styled>
-        <h1>
-          <span>AccordionExample</span>
-        </h1>
+    <>
+      <PageMeta
+        description="アコーディオンコンポーネントの利用例を確認できるサンプルページです。"
+        ogImage="/vite.svg"
+        shareText="アコーディオン UI サンプルページです。"
+        title="Accordion Example"
+      />
+      <Layout type="example">
+        <Styled>
+          <h1>
+            <span>AccordionExample</span>
+          </h1>
 
         {/* アコーディオン */}
         <Accordion className="mt-30" title="アコーディオンタイトル">
@@ -41,8 +49,9 @@ const AccordionExample: React.FC = () => {
             ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・
           </p>
         </Accordion>
-      </Styled>
-    </Layout>
+        </Styled>
+      </Layout>
+    </>
   );
 };
 

--- a/src/features/example/dropdownMenuExample/page.tsx
+++ b/src/features/example/dropdownMenuExample/page.tsx
@@ -2,7 +2,6 @@ import styled from "styled-components";
 
 import DropdownMenu from "../../../components/dropdownMenu/dropdownMenu";
 import Layout from "../../../components/layouts/layout";
-import PageMeta from "../../../components/seo/pageMeta";
 import { color, media } from "../../../lib/style";
 
 import type React from "react";
@@ -13,18 +12,19 @@ import type React from "react";
 
 const DropdownMenuExample: React.FC = () => {
   return (
-    <>
-      <PageMeta
-        description="ドロップダウンメニューの表示パターンを確認できるサンプルページです。"
-        ogImage="/vite.svg"
-        shareText="ドロップダウンメニュー UI のサンプルページです。"
-        title="Dropdown Menu Example"
-      />
-      <Layout type="example">
-        <Styled>
-          <h1>
-            <span>DropdownMenuExample</span>
-          </h1>
+    <Layout
+      meta={{
+        title: "Dropdown Menu Example",
+        description: "ドロップダウンメニューの表示パターンを確認できるサンプルページです。",
+        ogImage: "/vite.svg",
+        shareText: "ドロップダウンメニュー UI のサンプルページです。",
+      }}
+      type="example"
+    >
+      <Styled>
+        <h1>
+          <span>DropdownMenuExample</span>
+        </h1>
 
         {/* ドロップダウンメニュー */}
         <DropdownMenu
@@ -73,9 +73,8 @@ const DropdownMenuExample: React.FC = () => {
         >
           ドロップダウンメニュー_D
         </DropdownMenu>
-        </Styled>
-      </Layout>
-    </>
+      </Styled>
+    </Layout>
   );
 };
 

--- a/src/features/example/dropdownMenuExample/page.tsx
+++ b/src/features/example/dropdownMenuExample/page.tsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 
 import DropdownMenu from "../../../components/dropdownMenu/dropdownMenu";
 import Layout from "../../../components/layouts/layout";
+import PageMeta from "../../../components/seo/pageMeta";
 import { color, media } from "../../../lib/style";
 
 import type React from "react";
@@ -12,11 +13,18 @@ import type React from "react";
 
 const DropdownMenuExample: React.FC = () => {
   return (
-    <Layout type="example">
-      <Styled>
-        <h1>
-          <span>DropdownMenuExample</span>
-        </h1>
+    <>
+      <PageMeta
+        description="ドロップダウンメニューの表示パターンを確認できるサンプルページです。"
+        ogImage="/vite.svg"
+        shareText="ドロップダウンメニュー UI のサンプルページです。"
+        title="Dropdown Menu Example"
+      />
+      <Layout type="example">
+        <Styled>
+          <h1>
+            <span>DropdownMenuExample</span>
+          </h1>
 
         {/* ドロップダウンメニュー */}
         <DropdownMenu
@@ -65,8 +73,9 @@ const DropdownMenuExample: React.FC = () => {
         >
           ドロップダウンメニュー_D
         </DropdownMenu>
-      </Styled>
-    </Layout>
+        </Styled>
+      </Layout>
+    </>
   );
 };
 

--- a/src/features/example/formExample/page.tsx
+++ b/src/features/example/formExample/page.tsx
@@ -10,6 +10,7 @@ import SelectCustom from "../../../components/form/selectCustom";
 import SwitchButton from "../../../components/form/switchButton";
 import TextArea from "../../../components/form/textArea";
 import Layout from "../../../components/layouts/layout";
+import PageMeta from "../../../components/seo/pageMeta";
 import { color, media } from "../../../lib/style";
 import { testPostApi } from "../../../utils/apiHelper";
 
@@ -48,15 +49,22 @@ const FormExample: React.FC = () => {
   });
 
   return (
-    <Layout type="example">
-      <Styled>
-        <h1>
-          <span>
-            FormExample
-            <br />
-            <small>：react-hook-form</small>
-          </span>
-        </h1>
+    <>
+      <PageMeta
+        description="react-hook-form を使った入力フォームコンポーネントのサンプルページです。"
+        ogImage="/vite.svg"
+        shareText="フォーム実装サンプルをまとめたページです。"
+        title="Form Example"
+      />
+      <Layout type="example">
+        <Styled>
+          <h1>
+            <span>
+              FormExample
+              <br />
+              <small>：react-hook-form</small>
+            </span>
+          </h1>
 
         {/* インプット項目 */}
         <Input
@@ -179,8 +187,9 @@ const FormExample: React.FC = () => {
           </Button>
           <Button onClick={() => onSubmit()}>送信する</Button>
         </div>
-      </Styled>
-    </Layout>
+        </Styled>
+      </Layout>
+    </>
   );
 };
 

--- a/src/features/example/formExample/page.tsx
+++ b/src/features/example/formExample/page.tsx
@@ -10,7 +10,6 @@ import SelectCustom from "../../../components/form/selectCustom";
 import SwitchButton from "../../../components/form/switchButton";
 import TextArea from "../../../components/form/textArea";
 import Layout from "../../../components/layouts/layout";
-import PageMeta from "../../../components/seo/pageMeta";
 import { color, media } from "../../../lib/style";
 import { testPostApi } from "../../../utils/apiHelper";
 
@@ -49,22 +48,23 @@ const FormExample: React.FC = () => {
   });
 
   return (
-    <>
-      <PageMeta
-        description="react-hook-form を使った入力フォームコンポーネントのサンプルページです。"
-        ogImage="/vite.svg"
-        shareText="フォーム実装サンプルをまとめたページです。"
-        title="Form Example"
-      />
-      <Layout type="example">
-        <Styled>
-          <h1>
-            <span>
-              FormExample
-              <br />
-              <small>：react-hook-form</small>
-            </span>
-          </h1>
+    <Layout
+      meta={{
+        title: "Form Example",
+        description: "react-hook-form を使った入力フォームコンポーネントのサンプルページです。",
+        ogImage: "/vite.svg",
+        shareText: "フォーム実装サンプルをまとめたページです。",
+      }}
+      type="example"
+    >
+      <Styled>
+        <h1>
+          <span>
+            FormExample
+            <br />
+            <small>：react-hook-form</small>
+          </span>
+        </h1>
 
         {/* インプット項目 */}
         <Input
@@ -187,9 +187,8 @@ const FormExample: React.FC = () => {
           </Button>
           <Button onClick={() => onSubmit()}>送信する</Button>
         </div>
-        </Styled>
-      </Layout>
-    </>
+      </Styled>
+    </Layout>
   );
 };
 

--- a/src/features/example/modalExample/page.tsx
+++ b/src/features/example/modalExample/page.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import Button from "../../../components/button/button";
 import Layout from "../../../components/layouts/layout";
 import Modal from "../../../components/modal/modal";
+import PageMeta from "../../../components/seo/pageMeta";
 import { color, media } from "../../../lib/style";
 
 import type React from "react";
@@ -23,11 +24,18 @@ const ModalExample: React.FC = () => {
   };
 
   return (
-    <Layout type="example">
-      <Styled>
-        <h1>
-          <span>ModalExample</span>
-        </h1>
+    <>
+      <PageMeta
+        description="モーダルダイアログの表示と操作を確認できるサンプルページです。"
+        ogImage="/vite.svg"
+        shareText="モーダル UI の挙動を確認できるページです。"
+        title="Modal Example"
+      />
+      <Layout type="example">
+        <Styled>
+          <h1>
+            <span>ModalExample</span>
+          </h1>
 
         {/* ボタン */}
         <div className="button-clm">
@@ -55,8 +63,9 @@ const ModalExample: React.FC = () => {
         >
           ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト
         </Modal>
-      </Styled>
-    </Layout>
+        </Styled>
+      </Layout>
+    </>
   );
 };
 

--- a/src/features/example/modalExample/page.tsx
+++ b/src/features/example/modalExample/page.tsx
@@ -4,7 +4,6 @@ import styled from "styled-components";
 import Button from "../../../components/button/button";
 import Layout from "../../../components/layouts/layout";
 import Modal from "../../../components/modal/modal";
-import PageMeta from "../../../components/seo/pageMeta";
 import { color, media } from "../../../lib/style";
 
 import type React from "react";
@@ -24,18 +23,19 @@ const ModalExample: React.FC = () => {
   };
 
   return (
-    <>
-      <PageMeta
-        description="モーダルダイアログの表示と操作を確認できるサンプルページです。"
-        ogImage="/vite.svg"
-        shareText="モーダル UI の挙動を確認できるページです。"
-        title="Modal Example"
-      />
-      <Layout type="example">
-        <Styled>
-          <h1>
-            <span>ModalExample</span>
-          </h1>
+    <Layout
+      meta={{
+        title: "Modal Example",
+        description: "モーダルダイアログの表示と操作を確認できるサンプルページです。",
+        ogImage: "/vite.svg",
+        shareText: "モーダル UI の挙動を確認できるページです。",
+      }}
+      type="example"
+    >
+      <Styled>
+        <h1>
+          <span>ModalExample</span>
+        </h1>
 
         {/* ボタン */}
         <div className="button-clm">
@@ -63,9 +63,8 @@ const ModalExample: React.FC = () => {
         >
           ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト・ダミーテキスト
         </Modal>
-        </Styled>
-      </Layout>
-    </>
+      </Styled>
+    </Layout>
   );
 };
 

--- a/src/features/example/todoExample/page.tsx
+++ b/src/features/example/todoExample/page.tsx
@@ -4,7 +4,6 @@ import styled from "styled-components";
 import Button from "../../../components/button/button";
 import TodoItems from "../../../components/form/todoItems";
 import Layout from "../../../components/layouts/layout";
-import PageMeta from "../../../components/seo/pageMeta";
 import { color, media } from "../../../lib/style";
 
 import type { TypeTodoExampleValues } from "./type";
@@ -48,18 +47,19 @@ const TodoExample: React.FC = () => {
   });
 
   return (
-    <>
-      <PageMeta
-        description="動的に項目追加できる TODO フォームのサンプルページです。"
-        ogImage="/vite.svg"
-        shareText="TODO 管理 UI のサンプルを確認できます。"
-        title="Todo Example"
-      />
-      <Layout type="example">
-        <Styled>
-          <h1>
-            <span>TodoExample</span>
-          </h1>
+    <Layout
+      meta={{
+        title: "Todo Example",
+        description: "動的に項目追加できる TODO フォームのサンプルページです。",
+        ogImage: "/vite.svg",
+        shareText: "TODO 管理 UI のサンプルを確認できます。",
+      }}
+      type="example"
+    >
+      <Styled>
+        <h1>
+          <span>TodoExample</span>
+        </h1>
 
         {/* TODO項目 */}
         <TodoItems
@@ -81,9 +81,8 @@ const TodoExample: React.FC = () => {
           </Button>
           <Button onClick={() => onSubmit()}>送信する</Button>
         </div>
-        </Styled>
-      </Layout>
-    </>
+      </Styled>
+    </Layout>
   );
 };
 

--- a/src/features/example/todoExample/page.tsx
+++ b/src/features/example/todoExample/page.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import Button from "../../../components/button/button";
 import TodoItems from "../../../components/form/todoItems";
 import Layout from "../../../components/layouts/layout";
+import PageMeta from "../../../components/seo/pageMeta";
 import { color, media } from "../../../lib/style";
 
 import type { TypeTodoExampleValues } from "./type";
@@ -47,11 +48,18 @@ const TodoExample: React.FC = () => {
   });
 
   return (
-    <Layout type="example">
-      <Styled>
-        <h1>
-          <span>TodoExample</span>
-        </h1>
+    <>
+      <PageMeta
+        description="動的に項目追加できる TODO フォームのサンプルページです。"
+        ogImage="/vite.svg"
+        shareText="TODO 管理 UI のサンプルを確認できます。"
+        title="Todo Example"
+      />
+      <Layout type="example">
+        <Styled>
+          <h1>
+            <span>TodoExample</span>
+          </h1>
 
         {/* TODO項目 */}
         <TodoItems
@@ -73,8 +81,9 @@ const TodoExample: React.FC = () => {
           </Button>
           <Button onClick={() => onSubmit()}>送信する</Button>
         </div>
-      </Styled>
-    </Layout>
+        </Styled>
+      </Layout>
+    </>
   );
 };
 

--- a/src/lib/types/_componentsType.ts
+++ b/src/lib/types/_componentsType.ts
@@ -2,13 +2,14 @@
     ▽ 型定義 (コンポーネント編) ▽
 ---------------------------------------------------------- */
 
+import type { TypePageMetaProps } from "../../components/seo/pageMeta";
 import type { UseFormRegister } from "react-hook-form";
 
 // Header
 export type TypeHeader = { type: string };
 
 // Layout
-export type TypeLayout = { type: string; children?: React.ReactNode };
+export type TypeLayout = { type: string; meta?: TypePageMetaProps; children?: React.ReactNode };
 
 // Loading
 export type TypeLoading = { visible: boolean };

--- a/src/lib/types/_componentsType.ts
+++ b/src/lib/types/_componentsType.ts
@@ -2,7 +2,7 @@
     ▽ 型定義 (コンポーネント編) ▽
 ---------------------------------------------------------- */
 
-import type { TypePageMetaProps } from "../../components/seo/pageMeta";
+import type { TypePageMetaProps } from "../../components/layouts/pageMeta";
 import type { UseFormRegister } from "react-hook-form";
 
 // Header


### PR DESCRIPTION
### Motivation
- Provide per-page SEO and social share metadata (title, description, OGP image, OG/Twitter copy) so each `page.tsx` can declare its own values for better SEO/OGP/SNS sharing.
- Avoid adding a new runtime dependency for meta management and keep usage simple from page components.

### Description
- Add `src/components/seo/pageMeta.tsx` implementing a `PageMeta` component that accepts `title`, `description`, `ogImage`, optional `ogType`, and optional `shareText`, and updates `document.title` and meta tags (`description`, `og:*`, `twitter:*`) via DOM APIs in a `useEffect` hook.
- Integrate `PageMeta` into auth pages (`signIn`, `signUp`, `verification`, `signOut`) and example pages (`formExample`, `todoExample`, `modalExample`, `accordionExample`, `dropdownMenuExample`) so each page now supplies its own SEO/OG values.
- Decided against introducing `react-helmet-async`; the component updates the head directly to avoid requiring a new package.

### Testing
- Ran `npm run lint` (which runs `eslint` and `tsc --noEmit`) and it passed successfully.
- Attempted `yarn add react-helmet-async` and `yarn lint` in this environment but these failed due to lockfile/registry resolution errors; those failures influenced the decision to implement head updates without adding a dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db081de7a8832490b48a55f6c4a398)