### PR TITLE
refactor prerender to load pageMeta from page modules

### DIFF
--- a/src/router/prerender.mjs
+++ b/src/router/prerender.mjs
@@ -1,7 +1,8 @@
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import { createServer, loadEnv } from "vite";
+import ts from "typescript";
+import { loadEnv } from "vite";
 
 /* -----------------------------------------------
  * ◻︎◻︎◻︎ SEO対応 ◻︎◻︎◻︎
@@ -36,9 +37,34 @@ const findPageModules = async (dirPath) => {
   return pageModules;
 };
 
-const extractPageConfig = async (viteServer, pagePath) => {
-  const module = await viteServer.ssrLoadModule(`/${pagePath}`);
-  const pageMeta = module.pageMeta;
+const findPageMetaNode = (sourceFile) => {
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+
+    const hasExport = statement.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword);
+    if (!hasExport) continue;
+
+    for (const declaration of statement.declarationList.declarations) {
+      if (!ts.isIdentifier(declaration.name) || declaration.name.text !== "pageMeta") continue;
+      if (!declaration.initializer) continue;
+      return declaration.initializer;
+    }
+  }
+
+  return null;
+};
+
+const extractPageConfig = async (pagePath) => {
+  const source = await readFile(path.resolve(process.cwd(), pagePath), "utf8");
+  const sourceFile = ts.createSourceFile(pagePath, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const pageMetaNode = findPageMetaNode(sourceFile);
+
+  if (!pageMetaNode) {
+    throw new Error(`pageMeta export not found in ${pagePath}`);
+  }
+
+  const pageMetaSource = sourceFile.text.slice(pageMetaNode.pos, pageMetaNode.end).trim();
+  const pageMeta = Function(`"use strict"; return (${pageMetaSource});`)();
 
   if (!pageMeta) {
     throw new Error(`pageMeta export not found in ${pagePath}`);
@@ -114,30 +140,20 @@ const prerenderRootMarkup = (pageMeta) => {
 
 const run = async () => {
   const pageModules = await findPageModules(path.resolve(process.cwd(), "src/features"));
-  const viteServer = await createServer({
-    logLevel: "silent",
-    appType: "custom",
-    server: { middlewareMode: true },
-  });
-
   const distDir = path.resolve(process.cwd(), "dist");
   const indexPath = path.join(distDir, "index.html");
   const template = await readFile(indexPath, "utf8");
 
-  try {
-    for (const pagePath of pageModules) {
-      const { route, pageMeta } = await extractPageConfig(viteServer, pagePath);
-      const routeTemplate = withMeta(template, route, pageMeta).replace(
-        '<div id="root"></div>',
-        prerenderRootMarkup(pageMeta),
-      );
+  for (const pagePath of pageModules) {
+    const { route, pageMeta } = await extractPageConfig(pagePath);
+    const routeTemplate = withMeta(template, route, pageMeta).replace(
+      '<div id="root"></div>',
+      prerenderRootMarkup(pageMeta),
+    );
 
-      const outputDir = path.join(distDir, route.replace(/^\//, ""));
-      await mkdir(outputDir, { recursive: true });
-      await writeFile(path.join(outputDir, "index.html"), routeTemplate, "utf8");
-    }
-  } finally {
-    await viteServer.close();
+    const outputDir = path.join(distDir, route.replace(/^\//, ""));
+    await mkdir(outputDir, { recursive: true });
+    await writeFile(path.join(outputDir, "index.html"), routeTemplate, "utf8");
   }
 
   console.info(`Prerender completed for ${pageModules.length} routes.`);

--- a/src/router/prerender.mjs
+++ b/src/router/prerender.mjs
@@ -71,7 +71,7 @@ const extractPageConfig = async (pagePath) => {
   }
 
   const pageMetaSource = sourceFile.text.slice(pageMetaNode.pos, pageMetaNode.end).trim();
-  const pageMeta = Function(`"use strict"; return (${pageMetaSource});`)();
+  const pageMeta = new Function(`"use strict"; return (${pageMetaSource});`)();
 
   if (!pageMeta) {
     throw new Error(`pageMeta export not found in ${pagePath}`);

--- a/src/router/prerender.mjs
+++ b/src/router/prerender.mjs
@@ -1,13 +1,12 @@
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import ts from "typescript";
+import * as ts from "typescript";
 import { loadEnv } from "vite";
 
 /* -----------------------------------------------
- * ◻︎◻︎◻︎ SEO対応 ◻︎◻︎◻︎
- * yarn build:prerender コマンドで
- * 実行されるプリレンダリングスクリプト
+ * SEO、主にSNSシェア用のプリレンダリング対応
+ * yarn build:prerender コマンドで実行されるスクリプト
  * ----------------------------------------------- */
 
 const mode = process.env.VITE_ENV_MODE ?? process.env.NODE_ENV ?? "production";
@@ -41,7 +40,9 @@ const findPageMetaNode = (sourceFile) => {
   for (const statement of sourceFile.statements) {
     if (!ts.isVariableStatement(statement)) continue;
 
-    const hasExport = statement.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword);
+    const hasExport = statement.modifiers?.some(
+      (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword,
+    );
     if (!hasExport) continue;
 
     for (const declaration of statement.declarationList.declarations) {
@@ -56,7 +57,13 @@ const findPageMetaNode = (sourceFile) => {
 
 const extractPageConfig = async (pagePath) => {
   const source = await readFile(path.resolve(process.cwd(), pagePath), "utf8");
-  const sourceFile = ts.createSourceFile(pagePath, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const sourceFile = ts.createSourceFile(
+    pagePath,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
   const pageMetaNode = findPageMetaNode(sourceFile);
 
   if (!pageMetaNode) {

--- a/src/router/prerender.mjs
+++ b/src/router/prerender.mjs
@@ -1,7 +1,7 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import { loadEnv } from "vite";
+import { createServer, loadEnv } from "vite";
 
 /* -----------------------------------------------
  * ◻︎◻︎◻︎ SEO対応 ◻︎◻︎◻︎
@@ -16,32 +16,33 @@ const SITE_NAME = viteEnv.VITE_APP_SITE_NAME ?? "";
 const SITE_URL = viteEnv.VITE_APP_BASE_URL ?? "";
 const DEFAULT_OG_IMAGE = `${SITE_URL}${viteEnv.VITE_APP_DEFAULT_OG_IMAGE ?? ""}`;
 
-/*
- * プリレンダリング対象のページコンポーネントのパス
- */
-const prerenderTargets = [
-  /* example ページ */
-  "src/features/example/formExample/page.tsx",
-  "src/features/example/todoExample/page.tsx",
-  "src/features/example/modalExample/page.tsx",
-  "src/features/example/accordionExample/page.tsx",
-  "src/features/example/dropdownMenuExample/page.tsx",
-  /* auth ページ */
-  "src/features/auth/signIn/page.tsx",
-  "src/features/auth/signOut/page.tsx",
-  "src/features/auth/signUp/page.tsx",
-  "src/features/auth/verification/page.tsx",
-];
+const findPageModules = async (dirPath) => {
+  const entries = await readdir(dirPath, { withFileTypes: true });
+  const pageModules = [];
 
-const extractPageConfig = async (pagePath) => {
-  const source = await readFile(path.resolve(process.cwd(), pagePath), "utf8");
-  const pageMetaMatch = source.match(/export\s+const\s+pageMeta\s*=\s*(\{[\s\S]*?\});/);
+  for (const entry of entries) {
+    const fullPath = path.join(dirPath, entry.name);
 
-  if (!pageMetaMatch?.[1]) {
-    throw new Error(`pageMeta export not found in ${pagePath}`);
+    if (entry.isDirectory()) {
+      pageModules.push(...(await findPageModules(fullPath)));
+      continue;
+    }
+
+    if (entry.isFile() && entry.name === "page.tsx") {
+      pageModules.push(path.relative(process.cwd(), fullPath));
+    }
   }
 
-  const pageMeta = Function(`"use strict"; return (${pageMetaMatch[1]});`)();
+  return pageModules;
+};
+
+const extractPageConfig = async (viteServer, pagePath) => {
+  const module = await viteServer.ssrLoadModule(`/${pagePath}`);
+  const pageMeta = module.pageMeta;
+
+  if (!pageMeta) {
+    throw new Error(`pageMeta export not found in ${pagePath}`);
+  }
 
   if (!pageMeta.sharePath) {
     throw new Error(`sharePath missing in pageMeta of ${pagePath}`);
@@ -112,23 +113,34 @@ const prerenderRootMarkup = (pageMeta) => {
 };
 
 const run = async () => {
+  const pageModules = await findPageModules(path.resolve(process.cwd(), "src/features"));
+  const viteServer = await createServer({
+    logLevel: "silent",
+    appType: "custom",
+    server: { middlewareMode: true },
+  });
+
   const distDir = path.resolve(process.cwd(), "dist");
   const indexPath = path.join(distDir, "index.html");
   const template = await readFile(indexPath, "utf8");
 
-  for (const pagePath of prerenderTargets) {
-    const { route, pageMeta } = await extractPageConfig(pagePath);
-    const routeTemplate = withMeta(template, route, pageMeta).replace(
-      '<div id="root"></div>',
-      prerenderRootMarkup(pageMeta),
-    );
+  try {
+    for (const pagePath of pageModules) {
+      const { route, pageMeta } = await extractPageConfig(viteServer, pagePath);
+      const routeTemplate = withMeta(template, route, pageMeta).replace(
+        '<div id="root"></div>',
+        prerenderRootMarkup(pageMeta),
+      );
 
-    const outputDir = path.join(distDir, route.replace(/^\//, ""));
-    await mkdir(outputDir, { recursive: true });
-    await writeFile(path.join(outputDir, "index.html"), routeTemplate, "utf8");
+      const outputDir = path.join(distDir, route.replace(/^\//, ""));
+      await mkdir(outputDir, { recursive: true });
+      await writeFile(path.join(outputDir, "index.html"), routeTemplate, "utf8");
+    }
+  } finally {
+    await viteServer.close();
   }
 
-  console.info(`Prerender completed for ${prerenderTargets.length} routes.`);
+  console.info(`Prerender completed for ${pageModules.length} routes.`);
 };
 
 void run();


### PR DESCRIPTION
### Motivation

- Replace manual page list and fragile regex parsing so `pageMeta` can be consumed directly from each page module. 
- Make the prerender script discover pages automatically under `src/features` to avoid manual edits when pages are added.

### Description

- Added recursive discovery `findPageModules` to collect `src/features/**/page.tsx` files instead of a hard-coded `prerenderTargets` array. 
- Replaced file-source regex parsing with Vite SSR module loading by creating a temporary Vite server via `createServer` and using `ssrLoadModule` to read `export const pageMeta` from each `page.tsx`. 
- Added `readdir` import and updated imports to include `createServer`, and ensured the Vite server is closed in a `finally` block. 
- Updated completion log to report the number of discovered page modules rather than a fixed array length.

### Testing

- Ran `node --check src/router/prerender.mjs` and it returned no syntax errors. 
- Ran `npm run build:prerender`, which attempted a full build but failed due to missing project dependencies / TypeScript type resolution in this environment (expected outside this CI-less environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e35b4d70848324bd7330157e44202c)