### PR TITLE
Add canonical URL support in PageMeta metadata handling

### DIFF
--- a/src/components/layouts/pageMeta.tsx
+++ b/src/components/layouts/pageMeta.tsx
@@ -20,7 +20,8 @@ const PageMeta: React.FC<TypePageMeta> = ({ title, description, ogImage, ogType 
     const normalizedOgImage = ogImage?.trim() ? ogImage.trim() : DEFAULT_OG_IMAGE;
     const fullTitle =
       normalizedTitle === DEFAULT_TITLE ? DEFAULT_TITLE : `${normalizedTitle} | ${SITE_NAME}`;
-    const url = globalThis.location.href;
+    const currentUrl = new URL(globalThis.location.href);
+    const canonicalUrl = `${currentUrl.origin}${currentUrl.pathname}`;
     const ogImageUrl = String(normalizedOgImage).startsWith("http")
       ? normalizedOgImage
       : `${BASE_URL}${normalizedOgImage}`;
@@ -42,8 +43,18 @@ const PageMeta: React.FC<TypePageMeta> = ({ title, description, ogImage, ogType 
     upsertMeta("property", "og:title", fullTitle);
     upsertMeta("property", "og:description", normalizedDescription);
     upsertMeta("property", "og:type", ogType);
-    upsertMeta("property", "og:url", url);
+    upsertMeta("property", "og:url", canonicalUrl);
     upsertMeta("property", "og:site_name", SITE_NAME);
+
+    let canonicalTag = document.head.querySelector('link[rel="canonical"]');
+
+    if (!canonicalTag) {
+      canonicalTag = document.createElement("link");
+      canonicalTag.setAttribute("rel", "canonical");
+      document.head.appendChild(canonicalTag);
+    }
+
+    canonicalTag.setAttribute("href", canonicalUrl);
     upsertMeta("property", "og:image", ogImageUrl);
     upsertMeta("name", "twitter:card", "summary_large_image");
     upsertMeta("name", "twitter:title", fullTitle);

--- a/src/components/layouts/pageMeta.tsx
+++ b/src/components/layouts/pageMeta.tsx
@@ -45,6 +45,11 @@ const PageMeta: React.FC<TypePageMeta> = ({ title, description, ogImage, ogType 
     upsertMeta("property", "og:type", ogType);
     upsertMeta("property", "og:url", canonicalUrl);
     upsertMeta("property", "og:site_name", SITE_NAME);
+    upsertMeta("property", "og:image", ogImageUrl);
+    upsertMeta("name", "twitter:card", "summary_large_image");
+    upsertMeta("name", "twitter:title", fullTitle);
+    upsertMeta("name", "twitter:description", normalizedDescription);
+    upsertMeta("name", "twitter:image", ogImageUrl);
 
     let canonicalTag = document.head.querySelector('link[rel="canonical"]');
 
@@ -55,11 +60,6 @@ const PageMeta: React.FC<TypePageMeta> = ({ title, description, ogImage, ogType 
     }
 
     canonicalTag.setAttribute("href", canonicalUrl);
-    upsertMeta("property", "og:image", ogImageUrl);
-    upsertMeta("name", "twitter:card", "summary_large_image");
-    upsertMeta("name", "twitter:title", fullTitle);
-    upsertMeta("name", "twitter:description", normalizedDescription);
-    upsertMeta("name", "twitter:image", ogImageUrl);
   }, [description, ogImage, ogType, title]);
 
   return null;


### PR DESCRIPTION
### Motivation
- Use a canonical URL (origin + pathname) for page metadata to avoid including query strings and hashes in SEO/Open Graph URLs.

### Description
- Compute `canonicalUrl` from `globalThis.location.href` with `new URL(...)` and use `origin + pathname` as the canonical URL in `PageMeta`.
- Replace the `og:url` meta value to use `canonicalUrl` instead of the full href.
- Upsert a `<link rel="canonical">` element into `document.head` (create if missing) and set its `href` to `canonicalUrl` to keep the page canonical link synchronized.
- Change applied in `src/components/layouts/pageMeta.tsx` while preserving existing Open Graph and Twitter meta handling.

### Testing
- Ran `npm run -s lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e378eaaa2483249e965e2a3d11240a)