### PR TITLE
Add noindex support to PageMeta and exclude noindex pages from sitemap

### DIFF
--- a/scripts/build/prerender.mjs
+++ b/scripts/build/prerender.mjs
@@ -69,6 +69,12 @@ const withMeta = (template, route, pageMeta) => {
   nextHtml = upsertMeta(nextHtml, "name", "twitter:title", pageTitle);
   nextHtml = upsertMeta(nextHtml, "name", "twitter:description", pageMeta.description);
   nextHtml = upsertMeta(nextHtml, "name", "twitter:image", ogImageUrl);
+  nextHtml = upsertMeta(
+    nextHtml,
+    "name",
+    "robots",
+    pageMeta.noindex ? "noindex, nofollow" : "index, follow",
+  );
   nextHtml = upsertCanonical(nextHtml, canonicalUrl);
 
   return nextHtml;

--- a/scripts/build/sitemap.mjs
+++ b/scripts/build/sitemap.mjs
@@ -43,9 +43,9 @@ const buildSitemapXml = (routes) => {
 
 const run = async () => {
   const pageConfigs = await collectPageConfigs();
-  const routes = [...new Set(pageConfigs.map(({ route }) => route))].sort((a, b) =>
-    a.localeCompare(b),
-  );
+  const routes = [
+    ...new Set(pageConfigs.filter(({ pageMeta }) => !pageMeta.noindex).map(({ route }) => route)),
+  ].sort((a, b) => a.localeCompare(b));
   const sitemapXml = buildSitemapXml(routes);
   const outputPath = path.resolve(process.cwd(), "dist", "sitemap.xml");
 

--- a/src/components/layouts/pageMeta.tsx
+++ b/src/components/layouts/pageMeta.tsx
@@ -13,7 +13,13 @@ const DEFAULT_TITLE = import.meta.env.VITE_APP_DEFAULT_TITLE ?? "";
 const DEFAULT_DESCRIPTION = import.meta.env.VITE_APP_DEFAULT_DESCRIPTION ?? "";
 const DEFAULT_OG_IMAGE = import.meta.env.VITE_APP_DEFAULT_OG_IMAGE ?? "";
 
-const PageMeta: React.FC<TypePageMeta> = ({ title, description, ogImage, ogType = "website" }) => {
+const PageMeta: React.FC<TypePageMeta> = ({
+  title,
+  description,
+  noindex = false,
+  ogImage,
+  ogType = "website",
+}) => {
   useEffect(() => {
     const normalizedTitle = title?.trim() ? title.trim() : DEFAULT_TITLE;
     const normalizedDescription = description?.trim() ? description.trim() : DEFAULT_DESCRIPTION;
@@ -50,6 +56,7 @@ const PageMeta: React.FC<TypePageMeta> = ({ title, description, ogImage, ogType 
     upsertMeta("name", "twitter:title", fullTitle);
     upsertMeta("name", "twitter:description", normalizedDescription);
     upsertMeta("name", "twitter:image", ogImageUrl);
+    upsertMeta("name", "robots", noindex ? "noindex, nofollow" : "index, follow");
 
     let canonicalTag = document.head.querySelector('link[rel="canonical"]');
 
@@ -60,7 +67,7 @@ const PageMeta: React.FC<TypePageMeta> = ({ title, description, ogImage, ogType 
     }
 
     canonicalTag.setAttribute("href", canonicalUrl);
-  }, [description, ogImage, ogType, title]);
+  }, [description, noindex, ogImage, ogType, title]);
 
   return null;
 };

--- a/src/features/auth/signIn/page.tsx
+++ b/src/features/auth/signIn/page.tsx
@@ -18,9 +18,9 @@ export const pageMeta = {
   title: "Sign In",
   description: "メールアドレスとパスワードでログインするページです。",
   sharePath: "/auth/signin",
-  noindex: true,
   // ogImage: "/xxxx/xxxx.jpg",
   // ogType: "website" or "article",
+  // noindex: boolean,
 };
 
 const SignIn: React.FC = () => {

--- a/src/features/auth/signIn/page.tsx
+++ b/src/features/auth/signIn/page.tsx
@@ -18,6 +18,7 @@ export const pageMeta = {
   title: "Sign In",
   description: "メールアドレスとパスワードでログインするページです。",
   sharePath: "/auth/signin",
+  noindex: true,
   // ogImage: "/xxxx/xxxx.jpg",
   // ogType: "website" or "article",
 };

--- a/src/features/auth/signOut/page.tsx
+++ b/src/features/auth/signOut/page.tsx
@@ -15,7 +15,7 @@ export const pageMeta = {
   title: "Sign Out",
   description: "現在のセッションからサインアウトするページです。",
   sharePath: "/auth/signout",
-  noindex: true,
+  noindex: true, // SEO評価が無用なためnoindexを指定
   // ogImage: "/xxxx/xxxx.jpg",
   // ogType: "website" or "article",
 };

--- a/src/features/auth/signOut/page.tsx
+++ b/src/features/auth/signOut/page.tsx
@@ -15,6 +15,7 @@ export const pageMeta = {
   title: "Sign Out",
   description: "現在のセッションからサインアウトするページです。",
   sharePath: "/auth/signout",
+  noindex: true,
   // ogImage: "/xxxx/xxxx.jpg",
   // ogType: "website" or "article",
 };

--- a/src/features/auth/signUp/page.tsx
+++ b/src/features/auth/signUp/page.tsx
@@ -18,6 +18,7 @@ export const pageMeta = {
   title: "Sign Up",
   description: "メールアドレスとパスワードでアカウントを作成するページです。",
   sharePath: "/auth/signup",
+  noindex: true,
   // ogImage: "/xxxx/xxxx.jpg",
   // ogType: "website" or "article",
 };

--- a/src/features/auth/signUp/page.tsx
+++ b/src/features/auth/signUp/page.tsx
@@ -18,7 +18,7 @@ export const pageMeta = {
   title: "Sign Up",
   description: "メールアドレスとパスワードでアカウントを作成するページです。",
   sharePath: "/auth/signup",
-  noindex: true,
+  noindex: true, // SEO評価が無用なためnoindexを指定
   // ogImage: "/xxxx/xxxx.jpg",
   // ogType: "website" or "article",
 };

--- a/src/features/auth/verification/page.tsx
+++ b/src/features/auth/verification/page.tsx
@@ -18,7 +18,7 @@ export const pageMeta = {
   title: "Verification",
   description: "確認コードを入力してアカウント認証を完了するページです。",
   sharePath: "/auth/verification",
-  noindex: true,
+  noindex: true, // SEO評価が無用なためnoindexを指定
   // ogImage: "/xxxx/xxxx.jpg",
   // ogType: "website" or "article",
 };

--- a/src/features/auth/verification/page.tsx
+++ b/src/features/auth/verification/page.tsx
@@ -18,6 +18,7 @@ export const pageMeta = {
   title: "Verification",
   description: "確認コードを入力してアカウント認証を完了するページです。",
   sharePath: "/auth/verification",
+  noindex: true,
   // ogImage: "/xxxx/xxxx.jpg",
   // ogType: "website" or "article",
 };

--- a/src/features/example/accordionExample/page.tsx
+++ b/src/features/example/accordionExample/page.tsx
@@ -17,6 +17,7 @@ export const pageMeta = {
   sharePath: "/example/accordion_example",
   // ogImage: "/xxxx/xxxx.jpg",
   // ogType: "website" or "article",
+  // noindex: boolean,
 };
 
 const AccordionExample: React.FC = () => {

--- a/src/features/example/dropdownMenuExample/page.tsx
+++ b/src/features/example/dropdownMenuExample/page.tsx
@@ -17,6 +17,7 @@ export const pageMeta = {
   sharePath: "/example/dropdownmenu_example",
   // ogImage: "/xxxx/xxxx.jpg",
   // ogType: "website" or "article",
+  // noindex: boolean,
 };
 
 const DropdownMenuExample: React.FC = () => {

--- a/src/features/example/formExample/page.tsx
+++ b/src/features/example/formExample/page.tsx
@@ -27,6 +27,7 @@ export const pageMeta = {
   sharePath: "/example/form_example",
   // ogImage: "/xxxx/xxxx.jpg",
   // ogType: "website" or "article",
+  // noindex: boolean,
 };
 
 const FormExample: React.FC = () => {

--- a/src/features/example/modalExample/page.tsx
+++ b/src/features/example/modalExample/page.tsx
@@ -19,6 +19,7 @@ export const pageMeta = {
   sharePath: "/example/modal_example",
   // ogImage: "/xxxx/xxxx.jpg",
   // ogType: "website" or "article",
+  // noindex: boolean,
 };
 
 const ModalExample: React.FC = () => {

--- a/src/features/example/todoExample/page.tsx
+++ b/src/features/example/todoExample/page.tsx
@@ -20,6 +20,7 @@ export const pageMeta = {
   sharePath: "/example/todo_example",
   // ogImage: "/xxxx/xxxx.jpg",
   // ogType: "website" or "article",
+  // noindex: boolean,
 };
 
 const TodoExample: React.FC = () => {

--- a/src/lib/types/_componentsType.ts
+++ b/src/lib/types/_componentsType.ts
@@ -9,6 +9,7 @@ export type TypePageMeta = {
   title: string;
   description: string;
   sharePath: string;
+  noindex?: boolean;
   ogImage?: string;
   ogType?: "website" | "article";
 };


### PR DESCRIPTION
### Motivation
- 各ページで `noindex` を指定できるようにして、認証系ページ等を検索エンジンに評価させない（インデックスさせない）運用を可能にするため。プリレンダー HTML と `sitemap.xml` も同じ設定に従わせたい。

### Description
- `TypePageMeta` に `noindex?: boolean` を追加して型を拡張しました (`src/lib/types/_componentsType.ts`).
- 共通メタコンポーネント `PageMeta` を `noindex` に対応させ、`<meta name="robots">` を `noindex, nofollow` / `index, follow` で切り替えるようにしました (`src/components/layouts/pageMeta.tsx`).
- 指定どおり認証関連ページの `pageMeta` に `noindex: true` を設定しました（`/auth/signin`, `/auth/signup`, `/auth/verification`, `/auth/signout`）。
- ビルド時スクリプトを更新し、プリレンダー出力に同じ `robots` 指定を埋め込むようにし（`scripts/build/prerender.mjs`）、`sitemap.xml` 生成時には `pageMeta.noindex === true` のルートを除外するようにしました（`scripts/build/sitemap.mjs`）。

### Testing
- 型チェックを意図して `yarn -s tsc --noEmit` を実行しましたが、Yarn の実行環境でコマンド解釈のエラーにより失敗しました。
- 続けて `yarn run tsc --noEmit` を実行しましたが、ワークスペース / lockfile の解決エラーにより TypeScript チェックは実行できませんでした。
- そのため自動テストは今回実行できておらず、ローカルまたは CI 環境で `yarn install` 後に `yarn tsc --noEmit` と `yarn build` を実行して動作確認をお願いします。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e75f94f8b8832497c596e057ee6702)