### PR TITLE
グローバルローディングの安全なスコープ化: `withGlobalLoading` 追加と関連リファクタ

### DIFF
--- a/src/utils/apiHelper/index.ts
+++ b/src/utils/apiHelper/index.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import { loadingFlagDown, loadingFlagUp, store } from "../storeHelper";
+import { withGlobalLoading } from "../storeHelper";
 
 import type { TypeApiError, TypeFormExampleValues, TypeOptions } from "../../lib/types";
 import type { AxiosRequestConfig, AxiosResponse, Method } from "axios";
@@ -29,8 +29,6 @@ const execute = async <TResponse = unknown, TRequest = unknown>(
     isLoading = true,
   } = options;
 
-  if (isLoading) store.dispatch(loadingFlagUp());
-
   const bearerToken =
     accessToken ??
     (typeof sessionStorage !== "undefined"
@@ -51,27 +49,29 @@ const execute = async <TResponse = unknown, TRequest = unknown>(
     },
   };
 
-  try {
-    return await axios.request<TResponse>(requestConfig); // リクエスト実行
-  } catch (err) {
-    const failed_message = "API request failed";
+  const executeRequest = async () => {
+    try {
+      return await axios.request<TResponse>(requestConfig); // リクエスト実行
+    } catch (err) {
+      const failed_message = "API request failed";
 
-    if (axios.isAxiosError(err)) {
-      const message = err.response?.data ?? err.message;
-      console.error(failed_message, message);
+      if (axios.isAxiosError(err)) {
+        const message = err.response?.data ?? err.message;
+        console.error(failed_message, message);
 
-      return {
-        message: typeof err.message === "string" ? err.message : failed_message,
-        status: err.response?.status,
-        data: err.response?.data,
-      };
+        return {
+          message: typeof err.message === "string" ? err.message : failed_message,
+          status: err.response?.status,
+          data: err.response?.data,
+        };
+      }
+
+      console.error(failed_message, err);
+      throw err;
     }
+  };
 
-    console.error(failed_message, err);
-    throw err;
-  } finally {
-    if (isLoading) store.dispatch(loadingFlagDown());
-  }
+  return isLoading ? withGlobalLoading(executeRequest) : executeRequest();
 };
 
 /*

--- a/src/utils/authHelper/index.ts
+++ b/src/utils/authHelper/index.ts
@@ -3,7 +3,7 @@ import { confirmSignUp, signIn, signOut, signUp } from "aws-amplify/auth";
 import { useContext } from "react";
 
 import { AuthContext } from "../providerHelper/authProvider";
-import { loadingFlagDown, loadingFlagUp, store } from "../storeHelper";
+import { withGlobalLoading } from "../storeHelper";
 
 import type { TypeSignInValues, TypeSignUpValues, TypeVerifyValues } from "../../lib/types";
 
@@ -39,73 +39,65 @@ export const useAuth = () => {
  * サインイン 処理
  */
 export const signInHelper = async (data: TypeSignInValues) => {
-  store.dispatch(loadingFlagUp());
-
-  try {
-    const result = await signIn({ username: data.email, password: data.password });
-    console.warn("SignIn succeeded", result);
-    return true;
-  } catch (err) {
-    console.error(err);
-    return false;
-  } finally {
-    store.dispatch(loadingFlagDown());
-  }
+  return withGlobalLoading(async () => {
+    try {
+      const result = await signIn({ username: data.email, password: data.password });
+      console.warn("SignIn succeeded", result);
+      return true;
+    } catch (err) {
+      console.error(err);
+      return false;
+    }
+  });
 };
 
 /*
  * サインアップ 処理
  */
 export const signUpHelper = async (data: TypeSignUpValues) => {
-  store.dispatch(loadingFlagUp());
-
-  try {
-    const result = await signUp({
-      username: data.email,
-      password: data.password,
-      options: { userAttributes: { email: data.email } },
-    });
-    console.warn(result);
-    console.warn("SignUp succeeded");
-  } catch (err) {
-    console.error(err);
-  } finally {
-    store.dispatch(loadingFlagDown());
-  }
+  return withGlobalLoading(async () => {
+    try {
+      const result = await signUp({
+        username: data.email,
+        password: data.password,
+        options: { userAttributes: { email: data.email } },
+      });
+      console.warn(result);
+      console.warn("SignUp succeeded");
+    } catch (err) {
+      console.error(err);
+    }
+  });
 };
 
 /*
  * ベリファイ 処理
  */
 export const verifyHelper = async (data: TypeVerifyValues) => {
-  store.dispatch(loadingFlagUp());
-
-  try {
-    await confirmSignUp({ username: data.email, confirmationCode: data.verificationCode });
-    console.warn("verification succeeded");
-  } catch (err) {
-    console.warn(err);
-  } finally {
-    store.dispatch(loadingFlagDown());
-  }
+  return withGlobalLoading(async () => {
+    try {
+      await confirmSignUp({ username: data.email, confirmationCode: data.verificationCode });
+      console.warn("verification succeeded");
+    } catch (err) {
+      console.warn(err);
+    }
+  });
 };
 
 /*
  * サインアウト 処理
  */
 export const signOutHelper = async () => {
-  store.dispatch(loadingFlagUp());
-
-  try {
-    await signOut();
-    localStorage.clear();
-    console.warn("signed out");
-    return true;
-  } catch (err) {
-    console.warn(err);
-    localStorage.clear();
-    return false;
-  } finally {
-    store.dispatch(loadingFlagDown());
-  }
+  return withGlobalLoading(async () => {
+    try {
+      await signOut();
+      localStorage.clear();
+      console.warn("signed out");
+      return true;
+    } catch (err) {
+      console.warn(err);
+      localStorage.clear();
+      return false;
+    }
+  });
 };

--- a/src/utils/storeHelper/index.ts
+++ b/src/utils/storeHelper/index.ts
@@ -39,3 +39,27 @@ export const {
 } = appSlice.actions;
 
 export const store = configureStore({ reducer: appSlice.reducer });
+
+/*
+ * グローバルローディングの開始・終了を1セットで保証するユーティリティ
+ */
+const createLoadingScope = () => {
+  store.dispatch(loadingFlagUp());
+
+  let isClosed = false;
+  return () => {
+    if (isClosed) return;
+    isClosed = true;
+    store.dispatch(loadingFlagDown());
+  };
+};
+
+export const withGlobalLoading = async <T>(task: () => Promise<T>): Promise<T> => {
+  const closeLoading = createLoadingScope();
+
+  try {
+    return await task();
+  } finally {
+    closeLoading();
+  }
+};


### PR DESCRIPTION
### Motivation
- `loadingFlagUp()` を呼んで `loadingFlagDown()` を忘れるヒューマンエラーを防ぎ、必ず対となる処理でローディング表示を閉じられるようにするため。 
- API/認証処理のあちこちで手動で `Up/Down` を書いている現状を集中管理して可読性と安全性を上げるため。

### Description
- `src/utils/storeHelper/index.ts` に `withGlobalLoading` を追加し、内部で `loadingFlagUp()` を呼んで `try/finally` により必ず `loadingFlagDown()` を実行するスコープ付きユーティリティを実装した。 
- 二重クローズを防ぐための `createLoadingScope` と `isClosed` フラグを導入して、同一スコープでの多重呼び出しに耐性を持たせた。 
- `src/utils/apiHelper/index.ts` の API 実行ロジックを変更し、`isLoading` が `true` の場合は `withGlobalLoading(executeRequest)` でラップするようにして個別の `dispatch` を削除した。 
- `src/utils/authHelper/index.ts` の `signInHelper` / `signUpHelper` / `verifyHelper` / `signOutHelper` を `withGlobalLoading` を使う形にリファクタし、手動の `loadingFlagUp/down` ペアを削除した。 

### Testing
- 型チェックと ESLint を含むプロジェクトのリンター実行を `npm run lint` で実行し、正常終了した（`eslint` と `tsc --noEmit` が成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5b558fb88324835d03567fbf2a77)