### PR TITLE
sitemap: append trailing slash to generated <loc> URLs

### DIFF
--- a/scripts/build/sitemap.mjs
+++ b/scripts/build/sitemap.mjs
@@ -24,7 +24,10 @@ const buildSitemapXml = (routes) => {
   const today = new Date().toISOString().slice(0, 10);
   const urlRows = routes
     .map((route) => {
-      const routeWithTrailingSlash = route === "/" ? route : route.endsWith("/") ? route : `${route}/`;
+      let routeWithTrailingSlash = route;
+      if (route !== "/" && !route.endsWith("/")) {
+        routeWithTrailingSlash = `${route}/`;
+      }
 
       return [
         "  <url>",

--- a/scripts/build/sitemap.mjs
+++ b/scripts/build/sitemap.mjs
@@ -24,9 +24,11 @@ const buildSitemapXml = (routes) => {
   const today = new Date().toISOString().slice(0, 10);
   const urlRows = routes
     .map((route) => {
+      const routeWithTrailingSlash = route === "/" ? route : route.endsWith("/") ? route : `${route}/`;
+
       return [
         "  <url>",
-        `    <loc>${siteUrl}${route}</loc>`,
+        `    <loc>${siteUrl}${routeWithTrailingSlash}</loc>`,
         `    <lastmod>${today}</lastmod>`,
         "  </url>",
       ].join("\n");


### PR DESCRIPTION
### Motivation
- Ensure sitemap `<loc>` entries always include a trailing slash for non-root routes so URLs are emitted like `https://.../example/xxxxx_xxxxx/` instead of missing the trailing slash. 
- Preserve the site root (`/`) as-is so the base URL is unchanged.

### Description
- Updated `scripts/build/sitemap.mjs` to compute `routeWithTrailingSlash` and use it in the `<loc>` element. 
- The new logic leaves `route` unchanged when it is `/`, keeps it if it already ends with `/`, and otherwise appends a trailing `/`.
- No other files were modified.

### Testing
- Ran `yarn build` which completed successfully. 
- Ran `node scripts/build/sitemap.mjs` after the build and confirmed `sitemap.xml` was generated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f319548dc083248037c14214a138fb)