### PR TITLE
Add AppErrorBoundary, RouteGuard, lazy-loaded pages, PageLoading and auth status flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,3 +159,17 @@ react-cognit-practice/
 ├── ...
 └── README.md        # This file
 ```
+
+## 実装ルール（中規模までの拡張方針）
+
+元のシンプルな構成を保つため、機能追加時は以下のルールを目安にします。
+
+- 新しい画面は `src/features/<分類>/<画面名>/page.tsx` に追加する
+- その画面だけで使う処理・型・部品は、同じディレクトリの `util.ts`・`type.ts`・`component.tsx` に置く
+- 複数画面で再利用する UI だけを `src/components` に移す
+- 外部 API の呼び出しは画面へ直接書かず、`src/utils/apiHelper` を経由する
+- アプリ全体で共有する状態だけを Redux Store に置き、フォーム入力など画面内で完結する状態は `useState` / `react-hook-form` を使う
+- 認証が必要な画面は `src/router/routeGuard.tsx` を使い、各ページにリダイレクト条件を書かない
+- 画面は `src/router/index.tsx` で `lazy` 読み込みし、初期バンドルの肥大化を防ぐ
+
+認証状態は `loading`・`authenticated`・`unauthenticated` の3状態です。Cognito の初期確認中はルート判定を待つため、ログイン済みユーザーへ一瞬サインイン画面を表示することはありません。

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { BrowserRouter } from "react-router-dom";
 
+import AppErrorBoundary from "./components/error/appErrorBoundary";
 import GlobalLoading from "./components/loading/globalLoading";
 import { GlobalStyle } from "./lib/style";
 import { Router } from "./router";
@@ -21,7 +22,9 @@ const App = () => {
       <BrowserRouter>
         <GlobalStyle />
         <GlobalLoading />
-        <Router />
+        <AppErrorBoundary>
+          <Router />
+        </AppErrorBoundary>
       </BrowserRouter>
     </AppRootProvider>
   );

--- a/src/components/error/appErrorBoundary.tsx
+++ b/src/components/error/appErrorBoundary.tsx
@@ -1,0 +1,40 @@
+import { Component } from "react";
+
+import type React from "react";
+
+/* -----------------------------------------------
+ * 描画中の予期しないエラーをアプリ全体で受け止める
+ * ----------------------------------------------- */
+
+type AppErrorBoundaryState = { hasError: boolean };
+
+export class AppErrorBoundary extends Component<
+  React.PropsWithChildren,
+  AppErrorBoundaryState
+> {
+  state: AppErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): AppErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    // 監視サービス導入時は、この箇所からエラーを送信する
+    console.error("Unexpected application error", error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <main role="alert">
+          <h1>エラーが発生しました</h1>
+          <p>ページを再読み込みして、もう一度お試しください。</p>
+        </main>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default AppErrorBoundary;

--- a/src/components/loading/pageLoading.tsx
+++ b/src/components/loading/pageLoading.tsx
@@ -1,0 +1,24 @@
+import styled from "styled-components";
+
+import { color } from "../../lib/style";
+
+/* -----------------------------------------------
+ * 画面の遅延読み込み中に表示するローディング
+ * ----------------------------------------------- */
+
+export const PageLoading = () => (
+  <Styled aria-live="polite" role="status">
+    読み込み中...
+  </Styled>
+);
+
+const Styled = styled.div`
+  align-items: center;
+  color: ${color.black};
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  width: 100%;
+`;
+
+export default PageLoading;

--- a/src/lib/types/_authType.ts
+++ b/src/lib/types/_authType.ts
@@ -2,9 +2,12 @@
     ▽ 型定義 (Auth編) ▽
 ---------------------------------------------------------- */
 // AuthProvider
+export type TypeAuthStatus = "loading" | "authenticated" | "unauthenticated";
+
 export type TypeAuthContext = {
+  authStatus: TypeAuthStatus;
   isSignedIn: boolean;
-  refreshAuthState: () => void;
+  refreshAuthState: () => Promise<void>;
 };
 
 // SignIn

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,110 +1,121 @@
+import { lazy, Suspense } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 
-import SignIn from "../features/auth/signIn/page";
-import SignOut from "../features/auth/signOut/page";
-import SignUp from "../features/auth/signUp/page";
-import Verification from "../features/auth/verification/page";
-import Error404 from "../features/error/404/page";
-import Error500 from "../features/error/500/page";
-import AccordionExample from "../features/example/accordionExample/page";
-import DropdownMenuExample from "../features/example/dropdownMenuExample/page";
-import FormExample from "../features/example/formExample/page";
-import ModalExample from "../features/example/modalExample/page";
-import StoreExample from "../features/example/storeExample/page";
-import TodoExample from "../features/example/todoExample/page";
+import { RouteGuard } from "./routeGuard";
+import PageLoading from "../components/loading/pageLoading";
 import { useAuth } from "../utils/authHelper";
 import { usePVTracking } from "../utils/gaHelper";
 
 /* -----------------------------------------------
  * ルーティング設定
+ * ページ単位で遅延読み込みし、初期バンドルを小さく保つ
  * ----------------------------------------------- */
 
+const SignIn = lazy(() => import("../features/auth/signIn/page"));
+const SignOut = lazy(() => import("../features/auth/signOut/page"));
+const SignUp = lazy(() => import("../features/auth/signUp/page"));
+const Verification = lazy(() => import("../features/auth/verification/page"));
+const Error404 = lazy(() => import("../features/error/404/page"));
+const Error500 = lazy(() => import("../features/error/500/page"));
+const AccordionExample = lazy(
+  () => import("../features/example/accordionExample/page"),
+);
+const DropdownMenuExample = lazy(
+  () => import("../features/example/dropdownMenuExample/page"),
+);
+const FormExample = lazy(() => import("../features/example/formExample/page"));
+const ModalExample = lazy(
+  () => import("../features/example/modalExample/page"),
+);
+const StoreExample = lazy(
+  () => import("../features/example/storeExample/page"),
+);
+const TodoExample = lazy(() => import("../features/example/todoExample/page"));
+
 export function Router() {
-  const { isSignedIn } = useAuth(); // サインインフラグ
+  const { authStatus, isSignedIn } = useAuth();
 
   usePVTracking(); // GA4 PV計測処理
 
+  if (authStatus === "loading") return <PageLoading />;
+
   return (
-    <Routes>
-      {/* ----------------------------------------
-       * example 各ルート設定
-       * ----------------------------------------- */}
-      <Route element={<FormExample />} path="/example/form_example" />
-      <Route element={<TodoExample />} path="/example/todo_example" />
-      <Route element={<ModalExample />} path="/example/modal_example" />
-      <Route element={<AccordionExample />} path="/example/accordion_example" />
-      <Route
-        element={<DropdownMenuExample />}
-        path="/example/dropdownmenu_example"
-      />
-      <Route element={<StoreExample />} path="/example/store_example" />
+    <Suspense fallback={<PageLoading />}>
+      <Routes>
+        {/* example 各ルート設定 */}
+        <Route element={<FormExample />} path="/example/form_example" />
+        <Route element={<TodoExample />} path="/example/todo_example" />
+        <Route element={<ModalExample />} path="/example/modal_example" />
+        <Route
+          element={<AccordionExample />}
+          path="/example/accordion_example"
+        />
+        <Route
+          element={<DropdownMenuExample />}
+          path="/example/dropdownmenu_example"
+        />
+        <Route element={<StoreExample />} path="/example/store_example" />
 
-      {/* ----------------------------------------
-       * auth 各ルート設定
-       * ----------------------------------------- */}
-      <Route
-        element={
-          !isSignedIn ? <SignIn /> : <Navigate replace to="/auth/signout" />
-        }
-        path="/auth/signin"
-      />
-      <Route
-        element={
-          !isSignedIn ? <SignUp /> : <Navigate replace to="/auth/signout" />
-        }
-        path="/auth/signup"
-      />
-      <Route
-        element={
-          !isSignedIn ? (
-            <Verification />
-          ) : (
-            <Navigate replace to="/auth/signout" />
-          )
-        }
-        path="/auth/verification"
-      />
-      <Route
-        element={
-          isSignedIn ? <SignOut /> : <Navigate replace to="/auth/signin" />
-        }
-        path="/auth/signout"
-      />
+        {/* 未認証ユーザー向けルート */}
+        <Route
+          element={
+            <RouteGuard requireAuth={false}>
+              <SignIn />
+            </RouteGuard>
+          }
+          path="/auth/signin"
+        />
+        <Route
+          element={
+            <RouteGuard requireAuth={false}>
+              <SignUp />
+            </RouteGuard>
+          }
+          path="/auth/signup"
+        />
+        <Route
+          element={
+            <RouteGuard requireAuth={false}>
+              <Verification />
+            </RouteGuard>
+          }
+          path="/auth/verification"
+        />
 
-      {/* ----------------------------------------
-       * error 各ルート設定
-       * ----------------------------------------- */}
-      <Route element={<Error404 />} path="/error/404" />
-      <Route element={<Error500 />} path="/error/500" />
+        {/* 認証済みユーザー向けルート */}
+        <Route
+          element={
+            <RouteGuard requireAuth>
+              <SignOut />
+            </RouteGuard>
+          }
+          path="/auth/signout"
+        />
 
-      {/* ----------------------------------------
-       * リダイレクト設定
-       * ----------------------------------------- */}
-      <Route
-        // 存在しないパス遷移時は404ページへリダイレクト
-        element={<Navigate replace to="/error/404" />}
-        path="/*"
-      />
-      <Route
-        // ルート遷移時は FormExampleページ へリダイレクト
-        element={<Navigate replace to="/example/form_example" />}
-        path="/"
-      />
-      <Route
-        // example ルート遷移時は FormExampleページ へリダイレクト
-        element={<Navigate replace to="/example/form_example" />}
-        path="/example"
-      />
-      <Route
-        // auth ルート遷移時はサインイン状態に応じ SignOut/SignInページ へリダイレクト
-        element={
-          <Navigate
-            replace
-            to={isSignedIn ? "/auth/signout" : "/auth/signin"}
-          />
-        }
-        path="/auth"
-      />
-    </Routes>
+        {/* error 各ルート設定 */}
+        <Route element={<Error404 />} path="/error/404" />
+        <Route element={<Error500 />} path="/error/500" />
+
+        {/* リダイレクト設定 */}
+        <Route element={<Navigate replace to="/error/404" />} path="/*" />
+        <Route
+          element={<Navigate replace to="/example/form_example" />}
+          path="/"
+        />
+        <Route
+          element={<Navigate replace to="/example/form_example" />}
+          path="/example"
+        />
+        <Route
+          element={
+            <Navigate
+              replace
+              to={isSignedIn ? "/auth/signout" : "/auth/signin"}
+            />
+          }
+          path="/auth"
+        />
+      </Routes>
+    </Suspense>
   );
 }

--- a/src/router/routeGuard.tsx
+++ b/src/router/routeGuard.tsx
@@ -1,0 +1,34 @@
+import { Navigate } from "react-router-dom";
+
+import { useAuth } from "../utils/authHelper";
+
+import type React from "react";
+
+/* -----------------------------------------------
+ * 認証状態に応じたルート制御
+ * ----------------------------------------------- */
+
+type RouteGuardProps = {
+  children: React.ReactNode;
+  requireAuth: boolean;
+};
+
+export const RouteGuard: React.FC<RouteGuardProps> = ({
+  children,
+  requireAuth,
+}) => {
+  const { authStatus, isSignedIn } = useAuth();
+
+  // Cognito の確認が終わるまでは誤った画面へ遷移させない
+  if (authStatus === "loading") return null;
+
+  if (requireAuth && !isSignedIn) {
+    return <Navigate replace to="/auth/signin" />;
+  }
+
+  if (!requireAuth && isSignedIn) {
+    return <Navigate replace to="/auth/signout" />;
+  }
+
+  return children;
+};

--- a/src/utils/authHelper/authProvider.tsx
+++ b/src/utils/authHelper/authProvider.tsx
@@ -1,7 +1,13 @@
 import { getCurrentUser } from "aws-amplify/auth";
-import { createContext, useEffect, useMemo, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 
-import type { TypeAuthContext } from "../../lib/types";
+import type { TypeAuthContext, TypeAuthStatus } from "../../lib/types";
 import type React from "react";
 
 /* -----------------------------------------------
@@ -22,19 +28,25 @@ const getCurrentSignInFlag = async () => {
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const [isSignedIn, setIsSignedIn] = useState<boolean>(false);
+  const [authStatus, setAuthStatus] = useState<TypeAuthStatus>("loading");
 
-  const refreshAuthState = () => {
-    void getCurrentSignInFlag().then((flag) => {
-      setIsSignedIn(flag);
-    });
-  };
-
-  useEffect(() => {
-    refreshAuthState();
+  const refreshAuthState = useCallback(async () => {
+    const isSignedIn = await getCurrentSignInFlag();
+    setAuthStatus(isSignedIn ? "authenticated" : "unauthenticated");
   }, []);
 
-  const value = useMemo(() => ({ isSignedIn, refreshAuthState }), [isSignedIn]);
+  useEffect(() => {
+    void refreshAuthState();
+  }, [refreshAuthState]);
+
+  const value = useMemo(
+    () => ({
+      authStatus,
+      isSignedIn: authStatus === "authenticated",
+      refreshAuthState,
+    }),
+    [authStatus, refreshAuthState],
+  );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };


### PR DESCRIPTION
### Motivation

- Prevent unexpected render-time crashes from taking down the whole UI by adding a global error boundary. 
- Reduce initial bundle size by lazy-loading pages and showing a consistent loading UI during async imports. 
- Centralize route access control so pages redirect correctly based on authentication state and avoid transient flashes during Cognito initialization. 
- Standardize auth state to explicitly model `loading` / `authenticated` / `unauthenticated` and make refresh logic asynchronous.

### Description

- Add `AppErrorBoundary` component and wrap the app `Router` with it in `src/App.tsx` to show a simple fallback UI and log errors. 
- Introduce `PageLoading` component and use `Suspense` fallbacks with lazy-loaded route components in `src/router/index.tsx` to enable page-level code splitting. 
- Add `RouteGuard` component in `src/router/routeGuard.tsx` to enforce `requireAuth` rules and avoid showing incorrect pages while auth is `loading`. 
- Update auth provider (`src/utils/authHelper/authProvider.tsx`) to expose `authStatus: TypeAuthStatus`, compute `isSignedIn` from that status, and make `refreshAuthState` asynchronous. 
- Extend types (`src/lib/types/_authType.ts`) to include `TypeAuthStatus` and update `TypeAuthContext` accordingly. 
- Update routing to use `RouteGuard` for auth routes and redirect logic, and to return `PageLoading` while `authStatus === "loading"`. 
- Add implementation guidance to `README.md` describing page location, local utilities, shared components, API helper usage, auth handling, and lazy-loading policy.

### Testing

- Ran TypeScript typecheck with `tsc --noEmit` which completed successfully. 
- Ran ESLint (`yarn lint`) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b042bbcac8324b82877f132233b0f)