### PR TITLE
Fix Vitest page test setup and element queries

### DIFF
--- a/cdk/test/cdk.test.ts
+++ b/cdk/test/cdk.test.ts
@@ -1,6 +1,7 @@
 // import * as cdk from 'aws-cdk-lib';
 // import { Template } from 'aws-cdk-lib/assertions';
 // import * as Cdk from '../lib/cdk-stack';
+import { test } from "vitest";
 
 // example test. To run these tests, uncomment this file along with the
 // example resource in lib/cdk-stack.ts

--- a/test/features/auth/authPages.test.tsx
+++ b/test/features/auth/authPages.test.tsx
@@ -16,6 +16,8 @@ const authMocks = vi.hoisted(() => ({
   verify: vi.fn(),
 }));
 const EMAIL = "user@example.com";
+const EMAIL_PLACEHOLDER = "○○○○＠○○○○.com";
+const PASSWORD_PLACEHOLDER = "○○○○○○○○";
 
 vi.mock("../../../src/utils/authHelper", () => ({
   signInHelper: authMocks.signIn,
@@ -41,8 +43,8 @@ describe("authentication pages", () => {
     renderPage(<SignIn />);
 
     expect(screen.getByRole("heading", { name: "SignIn" })).toBeVisible();
-    await user.type(screen.getByLabelText(/emailを入力/), EMAIL);
-    await user.type(screen.getByLabelText(/passwordを入力/), "password");
+    await user.type(screen.getByPlaceholderText(EMAIL_PLACEHOLDER), EMAIL);
+    await user.type(screen.getByPlaceholderText(PASSWORD_PLACEHOLDER), "password");
     await user.click(screen.getByRole("button", { name: "送信する" }));
 
     await waitFor(() =>
@@ -59,8 +61,11 @@ describe("authentication pages", () => {
     renderPage(<SignUp />);
 
     expect(screen.getByRole("heading", { name: "SignUp" })).toBeVisible();
-    await user.type(screen.getByLabelText(/emailを入力/), "new@example.com");
-    await user.type(screen.getByLabelText(/passwordを入力/), "password");
+    await user.type(
+      screen.getByPlaceholderText(EMAIL_PLACEHOLDER),
+      "new@example.com",
+    );
+    await user.type(screen.getByPlaceholderText(PASSWORD_PLACEHOLDER), "password");
     await user.click(screen.getByRole("button", { name: "送信する" }));
 
     expect(await screen.findByText(/Verify用のコード/)).toBeVisible();
@@ -75,8 +80,8 @@ describe("authentication pages", () => {
     renderPage(<Verification />);
 
     expect(screen.getByRole("heading", { name: "Verification" })).toBeVisible();
-    await user.type(screen.getByLabelText(/verificationCodeを入力/), "123456");
-    await user.type(screen.getByLabelText(/emailを入力/), EMAIL);
+    await user.type(screen.getByPlaceholderText(PASSWORD_PLACEHOLDER), "123456");
+    await user.type(screen.getByPlaceholderText(EMAIL_PLACEHOLDER), EMAIL);
     await user.click(screen.getByRole("button", { name: "送信する" }));
 
     expect(await screen.findByText(/Verify 完了/)).toBeVisible();

--- a/test/features/example/examplePages.test.tsx
+++ b/test/features/example/examplePages.test.tsx
@@ -78,7 +78,7 @@ describe("example pages", () => {
       "updated",
     );
     expect(screen.getByText(/\[updated\]/)).toBeVisible();
-    await user.click(screen.getByRole("checkbox"));
+    await user.click(screen.getByText("noActive"));
     expect(screen.getByText(/\[true\]/)).toBeVisible();
   });
 

--- a/test/features/pageTestUtils.tsx
+++ b/test/features/pageTestUtils.tsx
@@ -1,7 +1,23 @@
 import { render } from "@testing-library/react";
+import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
+
+import { AuthContext } from "../../src/utils/authHelper/authProvider";
+import { store } from "../../src/utils/storeHelper";
 
 import type { ReactElement } from "react";
 
 export const renderPage = (page: ReactElement) =>
-  render(<MemoryRouter>{page}</MemoryRouter>);
+  render(
+    <Provider store={store}>
+      <AuthContext.Provider
+        value={{
+          isChecking: false,
+          isSignedIn: false,
+          refreshAuthState: () => undefined,
+        }}
+      >
+        <MemoryRouter>{page}</MemoryRouter>
+      </AuthContext.Provider>
+    </Provider>,
+  );


### PR DESCRIPTION
### Motivation
- Tests were failing due to missing React/Redux/Auth contexts in the shared page renderer and element queries that relied on labels not associated with inputs, causing DOM query failures. 
- A placeholder CDK test referenced `test` without importing it, producing `ReferenceError: test is not defined`.

### Description
- Wrap the shared test renderer `renderPage` with the Redux `<Provider>` and a test `AuthContext.Provider` that supplies `isChecking`, `isSignedIn`, and `refreshAuthState` so pages render with required contexts. 
- Update authentication page tests to query form controls by their existing `placeholder` text instead of `label` (introduce `EMAIL_PLACEHOLDER` and `PASSWORD_PLACEHOLDER` constants) to match the rendered markup. 
- Import Vitest's `test` in `cdk/test/cdk.test.ts` to fix the undefined `test` reference. 

### Testing
- `git diff --check` passed. 
- Attempted to run `yarn test` and direct `vitest` execution but the test runner could not be executed in this environment because the workspace Yarn configuration/lockfile state and registry access prevented resolving/running the local Vitest binary (registry returned HTTP 403), so full test run could not be completed here. 
- Attempts to run `tsc --noEmit` and `eslint` surfaced import-resolution errors in this environment because `vitest` and `@testing-library/react` types/binaries were not resolvable, which are environment/package-installation issues rather than regressions introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6caa5c15d48324baee5002769a6cdc)