### PR TITLE
PR と全ブランチ push の品質チェックを有効化し workflow を更新

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,154 +2,111 @@ name: workflow
 
 on:
   push:
-    branches:
-      - main
+  pull_request:
 
 jobs:
-  setup-node: # ジョブ名(名前は任意)
+  prettier-eslint-checker:
     runs-on: ubuntu-latest
-    timeout-minutes: 10 # デフォルトは360（6時間）のため短い時間で設定しておく
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 24.x
-
-      - name: Cache dependencies # node_modulesのキャッシュ
-        id: node_modules_cache_id # キャッシュID(名前は任意)
-        uses: actions/cache@v3
-        with:
-          path: "**/node_modules"
-          key: node-modules-key-${{ hashFiles('**/yarn.lock') }}
+          cache: yarn
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile --ignore-scripts
-
-  deploy-react-static: # ジョブ名(名前は任意)
-    runs-on: ubuntu-latest
-    needs: setup-node # 分岐元のジョブ
-    timeout-minutes: 10
-    env:
-      NODE_ENV: production
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 24.x
-
-      - name: Restore node_modules # キャッシュしたnode_modulesの使用
-        id: node_modules_cache_id # キャッシュしたnode_modulesのID
-        uses: actions/cache@v3
-        with:
-          path: "**/node_modules"
-          key: node-modules-key-${{ hashFiles('**/yarn.lock') }}
-
-      # - name: React-static Building
-      #   run: yarn build # SEO対策-無のビルドコマンド
-
-      - name: React-static Building
-        run: yarn build:scripts # SEO対策-有のビルドコマンド
-
-      - name: FTP-Deploy-Action
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.6 # FTPを使ってサーバーにDeployするアクションを実行
-        with:
-          server: ${{ secrets.FTP_SERVER }} # FTPサーバーのURLを設定
-          username: ${{ secrets.FTP_USERNAME }} # FTPのユーザー名を設定
-          password: ${{ secrets.FTP_PASSWORD }} # FTPのパスワードを設定
-          local-dir: ./dist/ # どのディレクトリのデータをアップロードするか
-          server-dir: /react-cognito/ # リモートのどのディレクトリにアップロードするか
-
-  deploy-storybook-static: # ジョブ名(名前は任意)
-    runs-on: ubuntu-latest
-    needs: setup-node # 分岐元のジョブ
-    timeout-minutes: 10
-    env:
-      NODE_ENV: production
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 24.x
-
-      - name: Restore node_modules # キャッシュしたnode_modulesの使用
-        id: node_modules_cache_id # キャッシュしたnode_modulesのID
-        uses: actions/cache@v3
-        with:
-          path: "**/node_modules"
-          key: node-modules-key-${{ hashFiles('**/yarn.lock') }}
-
-      - name: Storybook-static Building
-        run: yarn build-storybook
-
-      - name: FTP-Deploy-Action
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.6 # FTPを使ってサーバーにDeployするアクションを実行
-        with:
-          server: ${{ secrets.FTP_SERVER }} # FTPサーバーのURLを設定
-          username: ${{ secrets.FTP_USERNAME }} # FTPのユーザー名を設定
-          password: ${{ secrets.FTP_PASSWORD }} # FTPのパスワードを設定
-          local-dir: ./storybook-static/ # どのディレクトリのデータをアップロードするか
-          server-dir: /storybook/ # リモートのどのディレクトリにアップロードするか
-
-  prettier-eslint-checker: # ジョブ名(名前は任意)
-    runs-on: ubuntu-latest
-    needs: setup-node # 分岐元のジョブ
-    timeout-minutes: 10
-    env:
-      NODE_ENV: production
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 24.x
-
-      - name: Restore node_modules # キャッシュしたnode_modulesの使用
-        id: node_modules_cache_id # キャッシュしたnode_modulesのID
-        uses: actions/cache@v3
-        with:
-          path: "**/node_modules"
-          key: node-modules-key-${{ hashFiles('**/yarn.lock') }}
+        run: yarn install --immutable
 
       - name: Prettier-eslint Checker
-        run: yarn checker # Prettier・ESlintで未フォーマット箇所やLintエラーを検出
+        run: yarn checker
 
   vitest-run:
     runs-on: ubuntu-latest
-    needs: setup-node
     timeout-minutes: 10
     env:
       NODE_ENV: test
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 24.x
+          cache: yarn
 
-      - name: Restore node_modules
-        id: node_modules_cache_id
-        uses: actions/cache@v3
-        with:
-          path: "**/node_modules"
-          key: node-modules-key-${{ hashFiles('**/yarn.lock') }}
+      - name: Install dependencies
+        run: yarn install --immutable
 
       - name: Vitest Run
         run: yarn test
+
+  deploy-react-static:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      NODE_ENV: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: React-static Building
+        run: yarn build:scripts
+
+      - name: FTP-Deploy-Action
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.6
+        with:
+          server: ${{ secrets.FTP_SERVER }}
+          username: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          local-dir: ./dist/
+          server-dir: /react-cognito/
+
+  deploy-storybook-static:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      NODE_ENV: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Storybook-static Building
+        run: yarn build-storybook
+
+      - name: FTP-Deploy-Action
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.6
+        with:
+          server: ${{ secrets.FTP_SERVER }}
+          username: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          local-dir: ./storybook-static/
+          server-dir: /storybook/


### PR DESCRIPTION
### Motivation
- Pull Request のマージ前に最低限の品質ゲート（`yarn install --immutable`, `yarn checker`, `yarn test`）を必須化して問題の早期検出を行いたい。 
- `prettier`/`eslint` と `vitest` を全ブランチの push と PR のいずれでも走らせて、ブランチ単位での品質チェックを担保したい。 
- `actions/checkout` と `actions/setup-node` を最新の安定版に揃え、`node_modules` を直接キャッシュする旧来の方式から `setup-node` の Yarn キャッシュへ移行して信頼性を高めたい。 

### Description
- `.github/workflows/workflow.yml` のトリガーを全ブランチの `push` と `pull_request` に拡張しました。 
- `prettier-eslint-checker` ジョブを独立化して `yarn install --immutable` の後に `yarn checker` を実行するよう追加しました。 
- `vitest-run` ジョブを独立化して `yarn install --immutable` の後に `yarn test` を実行するよう追加しました。 
- `actions/checkout` と `actions/setup-node` を `v4` に更新し `cache: yarn` を有効化して `node_modules` 直接キャッシュを廃止し、`deploy-react-static` と `deploy-storybook-static` は引き続き `push` のうち `main` ブランチ時のみ実行されるよう `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` を追加しました。 

### Testing
- `git diff --check` を実行して整形チェックを行い成功しました。 
- `./node_modules/.bin/prettier --check .github/workflows/workflow.yml` を実行してワークフローファイルの Prettier チェックは成功しました。 
- `npm run checker` を実行しましたが、ローカルの Yarn 設定と既存の lockfile の不一致により `yarn lint` の起動で失敗しました。 
- `npm test` を実行しましたが、ローカルの `node_modules` に Vitest 実行ファイルが無いため失敗しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cba7fb6108324a5c78320bc640f55)