### PR TITLE
PR CIで静的サイトとStorybookのビルド検証を追加

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -47,12 +47,10 @@ jobs:
       - name: Vitest Run
         run: yarn test
 
-  deploy-react-static:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  build-scripts:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    env:
-      NODE_ENV: production
 
     steps:
       - name: Checkout
@@ -69,22 +67,13 @@ jobs:
 
       - name: React-static Building
         run: yarn build:scripts
+        env:
+          NODE_ENV: production
 
-      - name: FTP-Deploy-Action
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.6
-        with:
-          server: ${{ secrets.FTP_SERVER }}
-          username: ${{ secrets.FTP_USERNAME }}
-          password: ${{ secrets.FTP_PASSWORD }}
-          local-dir: ./dist/
-          server-dir: /react-cognito/
-
-  deploy-storybook-static:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  build-storybook:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    env:
-      NODE_ENV: production
 
     steps:
       - name: Checkout
@@ -101,6 +90,61 @@ jobs:
 
       - name: Storybook-static Building
         run: yarn build-storybook
+        env:
+          NODE_ENV: production
+
+  deploy-react-static:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: React-static Building
+        run: yarn build:scripts
+        env:
+          NODE_ENV: production
+
+      - name: FTP-Deploy-Action
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.6
+        with:
+          server: ${{ secrets.FTP_SERVER }}
+          username: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          local-dir: ./dist/
+          server-dir: /react-cognito/
+
+  deploy-storybook-static:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Storybook-static Building
+        run: yarn build-storybook
+        env:
+          NODE_ENV: production
 
       - name: FTP-Deploy-Action
         uses: SamKirkland/FTP-Deploy-Action@v4.3.6


### PR DESCRIPTION
### Motivation
- Pull Request 時に静的ビルドの入出力（React の prerender/sitemap 等）と Storybook の静的ビルドを事前検証して、本番ブランチへの不具合流入を防ぐため。 
- main ブランチのデプロイで `devDependencies` が除外されることで発生していた `ImportMeta.env` や `react-dom/client` 等の型・ビルドエラーを回避するため、`NODE_ENV=production` を依存関係インストールではなくビルドステップに限定する必要があるため。 

### Description
- `.github/workflows/workflow.yml` に Pull Request トリガーのジョブ `build-scripts` を追加し、`yarn build:scripts` を実行して React 静的サイトのビルドスクリプト出力を検証するようにしました。 
- 同ファイルに Pull Request トリガーのジョブ `build-storybook` を追加し、`yarn build-storybook` による Storybook の静的ビルド検証を行うようにしました。 
- `deploy-react-static` と `deploy-storybook-static` のワークフローでは、ジョブ全体の `env: NODE_ENV=production` を削除して、該当のビルドステップ実行時のみ `NODE_ENV=production` を渡すように変更し、インストール時に `devDependencies` が除外されないようにしました。 

### Testing
- `./node_modules/.bin/prettier --check .github/workflows/workflow.yml` を実行してフォーマットチェックは通りました。 
- `git diff --check` を実行してワークフローファイルの差分チェックに問題はありませんでした。 
- ローカルでの `tsc` / `vite build` / `storybook build` の直接実行は、ローカルの `node_modules` にテスト・ビルド用の `devDependencies` が不足しているか、環境のネットワーク制約により依存復元ができなかったため実行できませんでした（これらのビルドは新設した PR ジョブ上で検証される想定です）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cbfd9fc548324a7deda490fae084a)