### PR TITLE
Extract global loading control into `withGlobalLoading` and update auth flows

### DIFF
--- a/docs/loading-policy.md
+++ b/docs/loading-policy.md
@@ -1,0 +1,38 @@
+# Loading の運用方針
+
+Loading は、待機対象となる範囲に合わせて表示方法を選びます。API クライアントは通信だけを担当し、Loading の表示方法は呼び出し側が決定します。
+
+## Global Loading
+
+`withGlobalLoading` は、処理中に画面全体の操作を止める必要がある場合だけ使用します。
+
+- サインイン、サインアウトなど、完了前の別操作を避けたい処理
+- 決済など、二重実行の影響が大きい処理
+- 画面全体の前提となる状態を切り替える処理
+
+原則として、ページコンポーネントから直接呼び出さず、`useSignIn` のようなユースケースを表す hook 内で使用します。
+
+```ts
+const save = (data: SaveValues) => withGlobalLoading(() => saveHelper(data));
+```
+
+## Page / Local Loading
+
+次の処理では Global Loading を使用せず、対象範囲に loading 状態を表示します。
+
+- ページの初回データ取得: ページ内に skeleton または Loading を表示する
+- 一覧の再取得やページ送り: 一覧部分に Loading を表示する
+- フォーム送信: 必要に応じて送信ボタンを無効化し、ボタン内に Loading を表示する
+- ファイル送信: 対象領域に進捗を表示する
+
+## Background Loading
+
+キャッシュの再検証、定期更新、先読みなど、利用者の操作を止める必要がない通信では Loading を表示しません。失敗を利用者へ通知する必要がある場合は、処理の重要度に応じてインラインメッセージや通知を使用します。
+
+## 実装上のルール
+
+1. API クライアントへ UI の Loading 制御を追加しない。
+2. `loadingFlagUp` / `loadingFlagDown` をページから直接 dispatch しない。
+3. Global Loading が必要な処理は `withGlobalLoading` で開始・終了を必ず対にする。
+4. 同じ処理を複数の層で `withGlobalLoading` に包まない。
+5. 渡す Promise は、成功・失敗・キャンセルのいずれでも必ず settle するようにする。

--- a/src/features/auth/signIn/page.tsx
+++ b/src/features/auth/signIn/page.tsx
@@ -2,18 +2,13 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import styled from "styled-components";
 
+import { useSignIn } from "./util";
 import Button from "../../../components/button/button";
 import ErrorMessage from "../../../components/form/errorMessage";
 import Input from "../../../components/form/input";
 import Layout from "../../../components/layouts/layout";
-import { signInHelper, useAuth } from "../../../utils/authHelper";
-import {
-  loadingFlagDown,
-  loadingFlagUp,
-  store,
-} from "../../../utils/storeHelper";
 
-import type { SignInResult, SignInValues } from "./type";
+import type { SignInValues } from "./type";
 import type React from "react";
 
 /* -----------------------------------------------
@@ -22,7 +17,7 @@ import type React from "react";
 
 const SignIn: React.FC = () => {
   const [errorMessage, setErrorMessage] = useState("");
-  const { refreshAuthState } = useAuth(); // 認証状態を更新するための関数
+  const { signIn } = useSignIn();
 
   /*
    * RHForm 使用設定
@@ -42,27 +37,18 @@ const SignIn: React.FC = () => {
   /*
    * 「送信する」ボタン 処理
    */
-  const onSubmit = signInForm.handleSubmit((data) => {
-    store.dispatch(loadingFlagUp()); // ローディングフラグを上げる
-
-    /* Sign In 処理 */
-    signInHelper(data)
-      .then((res: SignInResult) => {
-        if (res.isSignedIn) {
-          refreshAuthState(); // 認証状態を更新する処理
-        } else {
-          onReset();
-          setErrorMessage("Sign In にはまだ追加手順（Verify）が必要だよ！");
-        }
-      })
-      .catch((err: unknown) => {
-        const message =
-          err instanceof Error ? err.message : "Sign In に失敗したよ...";
-        setErrorMessage(message);
-      })
-      .finally(() => {
-        store.dispatch(loadingFlagDown()); // ローディングフラグを下げる
-      });
+  const onSubmit = signInForm.handleSubmit(async (data) => {
+    try {
+      const result = await signIn(data);
+      if (!result.isSignedIn) {
+        onReset();
+        setErrorMessage("Sign In にはまだ追加手順（Verify）が必要だよ！");
+      }
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : "Sign In に失敗したよ...";
+      setErrorMessage(message);
+    }
   });
 
   return (

--- a/src/features/auth/signIn/util.ts
+++ b/src/features/auth/signIn/util.ts
@@ -1,3 +1,27 @@
 /* -----------------------------------------------
  * ページ固有の処理
  * ----------------------------------------------- */
+
+import { signInHelper, useAuth } from "../../../utils/authHelper";
+import { withGlobalLoading } from "../../../utils/loadingHelper";
+
+import type { SignInValues } from "./type";
+
+/*
+ * Sign In のユースケース
+ */
+export const useSignIn = () => {
+  const { refreshAuthState } = useAuth();
+
+  const signIn = async (data: SignInValues) => {
+    const result = await withGlobalLoading(() => signInHelper(data));
+
+    if (result.isSignedIn) {
+      refreshAuthState();
+    }
+
+    return result;
+  };
+
+  return { signIn };
+};

--- a/src/features/auth/signOut/page.tsx
+++ b/src/features/auth/signOut/page.tsx
@@ -1,15 +1,10 @@
 import { useState } from "react";
 import styled from "styled-components";
 
+import { useSignOut } from "./util";
 import Button from "../../../components/button/button";
 import ErrorMessage from "../../../components/form/errorMessage";
 import Layout from "../../../components/layouts/layout";
-import { signOutHelper, useAuth } from "../../../utils/authHelper";
-import {
-  loadingFlagDown,
-  loadingFlagUp,
-  store,
-} from "../../../utils/storeHelper";
 
 import type React from "react";
 
@@ -19,28 +14,21 @@ import type React from "react";
 
 const SignOut: React.FC = () => {
   const [errorMessage, setErrorMessage] = useState("");
-  const { refreshAuthState } = useAuth(); // 認証状態を更新するための関数
+  const { signOut } = useSignOut();
 
   /*
    * 「Sign Out」ボタン 処理
    */
-  const signOut = () => {
-    store.dispatch(loadingFlagUp()); // ローディングフラグを上げる
+  const onSignOut = async () => {
     setErrorMessage("");
 
-    /* Sign Out 処理 */
-    signOutHelper()
-      .then(() => {
-        refreshAuthState(); // Auth情報 取得・更新処理
-      })
-      .catch((err: unknown) => {
-        const message =
-          err instanceof Error ? err.message : "Sign Out に失敗したよ...";
-        setErrorMessage(message);
-      })
-      .finally(() => {
-        store.dispatch(loadingFlagDown()); // ローディングフラグを下げる
-      });
+    try {
+      await signOut();
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : "Sign Out に失敗したよ...";
+      setErrorMessage(message);
+    }
   };
 
   return (
@@ -53,7 +41,7 @@ const SignOut: React.FC = () => {
 
         {/* ボタン */}
         <div className="mt-30">
-          <Button onClick={signOut}>Sign Out</Button>
+          <Button onClick={onSignOut}>Sign Out</Button>
         </div>
       </Styled>
     </Layout>

--- a/src/features/auth/signOut/util.ts
+++ b/src/features/auth/signOut/util.ts
@@ -1,3 +1,20 @@
 /* -----------------------------------------------
  * ページ固有の処理
  * ----------------------------------------------- */
+
+import { signOutHelper, useAuth } from "../../../utils/authHelper";
+import { withGlobalLoading } from "../../../utils/loadingHelper";
+
+/*
+ * Sign Out のユースケース
+ */
+export const useSignOut = () => {
+  const { refreshAuthState } = useAuth();
+
+  const signOut = async () => {
+    await withGlobalLoading(signOutHelper);
+    refreshAuthState();
+  };
+
+  return { signOut };
+};

--- a/src/features/auth/signUp/page.tsx
+++ b/src/features/auth/signUp/page.tsx
@@ -2,17 +2,12 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import styled from "styled-components";
 
+import { useSignUp } from "./util";
 import Button from "../../../components/button/button";
 import ErrorMessage from "../../../components/form/errorMessage";
 import Input from "../../../components/form/input";
 import Layout from "../../../components/layouts/layout";
 import { color } from "../../../lib/style";
-import { signUpHelper } from "../../../utils/authHelper";
-import {
-  loadingFlagDown,
-  loadingFlagUp,
-  store,
-} from "../../../utils/storeHelper";
 
 import type { SignUpResult, SignUpValues } from "./type";
 import type React from "react";
@@ -24,6 +19,7 @@ import type React from "react";
 const SignUp: React.FC = () => {
   const [errorMessage, setErrorMessage] = useState("");
   const [successMessage, setSuccessMessage] = useState("");
+  const { signUp } = useSignUp();
 
   /*
    * RHForm 使用設定
@@ -44,27 +40,20 @@ const SignUp: React.FC = () => {
   /*
    * 「送信する」ボタン 処理
    */
-  const onSubmit = signUpForm.handleSubmit((data) => {
-    store.dispatch(loadingFlagUp()); // ローディングフラグを上げる
-
-    /* Sign Up 処理 */
-    signUpHelper(data)
-      .then((res: SignUpResult) => {
-        const noVerify = res.isSignUpComplete === true; // verifyの手順必要かフラグ
-        const message = noVerify
-          ? "Sign Up 成功! Sign In しよう！" // verify 不要時
-          : "OK！ Verify用のコードをメールで送ったから確認してね！"; // verify 必要時
-        onReset();
-        setSuccessMessage(message);
-      })
-      .catch((err: unknown) => {
-        const message =
-          err instanceof Error ? err.message : "Sign Up に失敗したよ...";
-        setErrorMessage(message);
-      })
-      .finally(() => {
-        store.dispatch(loadingFlagDown()); // ローディングフラグを下げる
-      });
+  const onSubmit = signUpForm.handleSubmit(async (data) => {
+    try {
+      const result: SignUpResult = await signUp(data);
+      const noVerify = result.isSignUpComplete === true; // verifyの手順必要かフラグ
+      const message = noVerify
+        ? "Sign Up 成功! Sign In しよう！" // verify 不要時
+        : "OK！ Verify用のコードをメールで送ったから確認してね！"; // verify 必要時
+      onReset();
+      setSuccessMessage(message);
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : "Sign Up に失敗したよ...";
+      setErrorMessage(message);
+    }
   });
 
   return (

--- a/src/features/auth/signUp/util.ts
+++ b/src/features/auth/signUp/util.ts
@@ -1,3 +1,18 @@
 /* -----------------------------------------------
  * ページ固有の処理
  * ----------------------------------------------- */
+
+import { signUpHelper } from "../../../utils/authHelper";
+import { withGlobalLoading } from "../../../utils/loadingHelper";
+
+import type { SignUpValues } from "./type";
+
+/*
+ * Sign Up のユースケース
+ */
+export const useSignUp = () => {
+  const signUp = (data: SignUpValues) =>
+    withGlobalLoading(() => signUpHelper(data));
+
+  return { signUp };
+};

--- a/src/features/auth/verification/page.tsx
+++ b/src/features/auth/verification/page.tsx
@@ -2,17 +2,12 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import styled from "styled-components";
 
+import { useVerification } from "./util";
 import Button from "../../../components/button/button";
 import ErrorMessage from "../../../components/form/errorMessage";
 import Input from "../../../components/form/input";
 import Layout from "../../../components/layouts/layout";
 import { color } from "../../../lib/style";
-import { verifyHelper } from "../../../utils/authHelper";
-import {
-  loadingFlagDown,
-  loadingFlagUp,
-  store,
-} from "../../../utils/storeHelper";
 
 import type { VerifyValues } from "./type";
 import type React from "react";
@@ -24,6 +19,7 @@ import type React from "react";
 const Verification: React.FC = () => {
   const [errorMessage, setErrorMessage] = useState("");
   const [successMessage, setSuccessMessage] = useState("");
+  const { verify } = useVerification();
 
   /*
    * RHForm 使用設定
@@ -44,23 +40,16 @@ const Verification: React.FC = () => {
   /*
    * 「送信する」ボタン 処理
    */
-  const onSubmit = verifyForm.handleSubmit((data) => {
-    store.dispatch(loadingFlagUp()); // ローディングフラグを上げる
-
-    /* Verify 処理 */
-    verifyHelper(data)
-      .then(() => {
-        onReset();
-        setSuccessMessage("Verify 完了、Sign In できるよ！");
-      })
-      .catch((err: unknown) => {
-        const message =
-          err instanceof Error ? err.message : "Verify に失敗したよ...";
-        setErrorMessage(message);
-      })
-      .finally(() => {
-        store.dispatch(loadingFlagDown()); // ローディングフラグを下げる
-      });
+  const onSubmit = verifyForm.handleSubmit(async (data) => {
+    try {
+      await verify(data);
+      onReset();
+      setSuccessMessage("Verify 完了、Sign In できるよ！");
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : "Verify に失敗したよ...";
+      setErrorMessage(message);
+    }
   });
 
   return (

--- a/src/features/auth/verification/util.ts
+++ b/src/features/auth/verification/util.ts
@@ -1,3 +1,18 @@
 /* -----------------------------------------------
  * ページ固有の処理
  * ----------------------------------------------- */
+
+import { verifyHelper } from "../../../utils/authHelper";
+import { withGlobalLoading } from "../../../utils/loadingHelper";
+
+import type { VerifyValues } from "./type";
+
+/*
+ * Verification のユースケース
+ */
+export const useVerification = () => {
+  const verify = (data: VerifyValues) =>
+    withGlobalLoading(() => verifyHelper(data));
+
+  return { verify };
+};

--- a/src/lib/types/_apiHelperType.ts
+++ b/src/lib/types/_apiHelperType.ts
@@ -16,7 +16,6 @@ export type RequestOptions<TRequest> = {
   apiPath: string;
   baseURL?: string;
   headers?: Record<string, string>;
-  isLoading?: boolean;
   method: Method;
   params?: Record<string, unknown>;
   requestData?: TRequest;

--- a/src/utils/apiHelper/client.ts
+++ b/src/utils/apiHelper/client.ts
@@ -1,8 +1,6 @@
 import { fetchAuthSession } from "aws-amplify/auth";
 import axios from "axios";
 
-import { loadingFlagDown, loadingFlagUp, store } from "../storeHelper";
-
 import type { ApiResult, RequestOptions } from "../../lib/types";
 import type { AxiosRequestConfig, Method } from "axios";
 
@@ -45,13 +43,10 @@ const execute = async <TResponse, TRequest>(
     apiPath,
     baseURL = DEFAULT_BASE_URL,
     headers,
-    isLoading = true,
     method,
     params,
     requestData,
   } = options;
-
-  if (isLoading) store.dispatch(loadingFlagUp()); // ローディングフラグを上げる
 
   try {
     // リクエスト内容
@@ -79,8 +74,6 @@ const execute = async <TResponse, TRequest>(
       };
     }
     throw error;
-  } finally {
-    if (isLoading) store.dispatch(loadingFlagDown()); // ローディングフラグを下げる
   }
 };
 

--- a/src/utils/apiHelper/modules/exampleApi.ts
+++ b/src/utils/apiHelper/modules/exampleApi.ts
@@ -15,12 +15,11 @@ export const testPostApi = <TRequest>(data: TRequest) => {
 };
 
 /*
- * export const postXXXXApi = (params, baseURL, headers, requestData, accessToken, isLoading) => {
+ * export const postXXXXApi = (params, baseURL, headers, requestData, accessToken) => {
  *  const options = {
  *    accessToken?, // アクセストークン
  *    baseURL?, // DEFAULT_BASE_URL を使わない際のベースURL
  *    headers?, // 追加ヘッダー情報を付与
- *    isLoading?, // ローディングフラグ制御
  *    params?, // クエリパラム
  *    requestData?, // リクエストデータ（リクエストボディ）
  *  };

--- a/src/utils/loadingHelper/index.ts
+++ b/src/utils/loadingHelper/index.ts
@@ -1,0 +1,35 @@
+import { loadingFlagDown, loadingFlagUp, store } from "../storeHelper";
+
+/* -----------------------------------------------
+ * グローバルローディング制御
+ *
+ * 画面全体の操作を止める必要がある処理だけで使用する。
+ * API クライアントは表示方法を決めず、呼び出し側が明示的に選択する。
+ * ----------------------------------------------- */
+
+const createLoadingScope = () => {
+  store.dispatch(loadingFlagUp());
+
+  let isClosed = false;
+  return () => {
+    if (isClosed) return;
+
+    isClosed = true;
+    store.dispatch(loadingFlagDown());
+  };
+};
+
+/*
+ * 非同期処理の開始・終了を1セットで保証する
+ */
+export const withGlobalLoading = async <T>(
+  task: () => Promise<T>,
+): Promise<T> => {
+  const closeLoading = createLoadingScope();
+
+  try {
+    return await task();
+  } finally {
+    closeLoading();
+  }
+};

--- a/test/utils/apiClient.test.ts
+++ b/test/utils/apiClient.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { request } from "../../src/utils/apiHelper/client";
+import { loadingFlagDown, store } from "../../src/utils/storeHelper";
+
+const mocks = vi.hoisted(() => ({
+  fetchAuthSession: vi.fn(),
+  isAxiosError: vi.fn(),
+  request: vi.fn(),
+}));
+
+vi.mock("aws-amplify/auth", () => ({
+  fetchAuthSession: mocks.fetchAuthSession,
+}));
+
+vi.mock("axios", () => ({
+  default: {
+    isAxiosError: mocks.isAxiosError,
+    request: mocks.request,
+  },
+}));
+
+const resetLoadingCount = () => {
+  while (store.getState().loading.count > 0) {
+    store.dispatch(loadingFlagDown());
+  }
+};
+
+describe("API client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetLoadingCount();
+    mocks.fetchAuthSession.mockResolvedValue({
+      tokens: { accessToken: { toString: () => "session-token" } },
+    });
+  });
+
+  it("adds the session token without changing global loading", async () => {
+    mocks.request.mockResolvedValue({
+      data: { id: 1 },
+      headers: {},
+      status: 200,
+    });
+
+    const result = await request("GET", "/articles", {
+      baseURL: "https://example.com",
+    });
+
+    expect(mocks.request).toHaveBeenCalledWith({
+      data: undefined,
+      headers: {
+        Accept: "application/json",
+        Authorization: "Bearer session-token",
+        "Content-Type": "application/json",
+      },
+      method: "GET",
+      params: undefined,
+      url: "https://example.com/articles",
+    });
+    expect(result).toEqual({
+      ok: true,
+      response: { data: { id: 1 }, headers: {}, status: 200 },
+    });
+    expect(store.getState().loading.count).toBe(0);
+  });
+
+  it("normalizes an Axios error without changing global loading", async () => {
+    const error = {
+      message: "Request failed",
+      response: { data: { reason: "invalid" }, status: 400 },
+    };
+    mocks.request.mockRejectedValue(error);
+    mocks.isAxiosError.mockReturnValue(true);
+
+    await expect(request("POST", "/articles")).resolves.toEqual({
+      error: {
+        data: { reason: "invalid" },
+        message: "Request failed",
+        status: 400,
+      },
+      ok: false,
+    });
+    expect(store.getState().loading.count).toBe(0);
+  });
+
+  it("rethrows an unexpected error", async () => {
+    const error = new Error("Unexpected failure");
+    mocks.request.mockRejectedValue(error);
+    mocks.isAxiosError.mockReturnValue(false);
+
+    await expect(request("GET", "/articles")).rejects.toBe(error);
+    expect(store.getState().loading.count).toBe(0);
+  });
+});

--- a/test/utils/loadingHelper.test.ts
+++ b/test/utils/loadingHelper.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { withGlobalLoading } from "../../src/utils/loadingHelper";
+import { loadingFlagDown, store } from "../../src/utils/storeHelper";
+
+const resetLoadingCount = () => {
+  while (store.getState().loading.count > 0) {
+    store.dispatch(loadingFlagDown());
+  }
+};
+
+describe("withGlobalLoading", () => {
+  beforeEach(resetLoadingCount);
+
+  it("returns the task result and closes loading after success", async () => {
+    const result = await withGlobalLoading(() => Promise.resolve("completed"));
+
+    expect(result).toBe("completed");
+    expect(store.getState().loading.count).toBe(0);
+  });
+
+  it("closes loading and rethrows when the task fails", async () => {
+    const error = new Error("failed");
+
+    await expect(withGlobalLoading(() => Promise.reject(error))).rejects.toBe(
+      error,
+    );
+    expect(store.getState().loading.count).toBe(0);
+  });
+
+  it("keeps loading visible until every concurrent task finishes", async () => {
+    let finishFirst: (() => void) | undefined;
+    let finishSecond: (() => void) | undefined;
+    const firstTask = new Promise<void>((resolve) => {
+      finishFirst = resolve;
+    });
+    const secondTask = new Promise<void>((resolve) => {
+      finishSecond = resolve;
+    });
+
+    const first = withGlobalLoading(() => firstTask);
+    const second = withGlobalLoading(() => secondTask);
+    expect(store.getState().loading.count).toBe(2);
+
+    finishFirst?.();
+    await first;
+    expect(store.getState().loading.count).toBe(1);
+
+    finishSecond?.();
+    await second;
+    expect(store.getState().loading.count).toBe(0);
+  });
+});


### PR DESCRIPTION
### Motivation

- Prevent UI concerns (global loading state) from being handled inside the API client and instead let call sites decide how to display loading. 
- Provide a small, safe abstraction to ensure global loading start/stop are paired and resilient to errors or concurrent tasks. 
- Clarify loading usage patterns for the team by adding a short operational policy document.

### Description

- Add `src/utils/loadingHelper/index.ts` with `withGlobalLoading` which dispatches `loadingFlagUp`/`loadingFlagDown` via `store` and guarantees paired start/stop even on errors or concurrent tasks. 
- Remove `isLoading` from `RequestOptions<T>` and strip all loading dispatches out of the API client (`src/utils/apiHelper/client.ts`) so the client no longer mutates global loading state. 
- Introduce per-page use-case hooks (`useSignIn`, `useSignOut`, `useSignUp`, `useVerification`) that wrap existing `*Helper` functions with `withGlobalLoading` and update corresponding pages to call those hooks (pages now await hook results and handle UI-only state like error/success messages). 
- Add `docs/loading-policy.md` describing when to use global/page/background loading and implementation rules. 
- Add unit tests for the loading helper and API client behavior at `test/utils/loadingHelper.test.ts` and `test/utils/apiClient.test.ts` and adjust inline API example comments to reflect the removed `isLoading` option.

### Testing

- Added unit tests `test/utils/loadingHelper.test.ts` to validate `withGlobalLoading` closes loading on success/failure and handles concurrent scopes, and `test/utils/apiClient.test.ts` to ensure the API client no longer mutates global loading and normalizes Axios errors; both tests were executed with Vitest and passed. 
- The tests exercise that global loading `count` returns to `0` after each scenario and that the API client still returns normalized success/error results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a74b683ea708324aae69a2998798e96)