### PR TITLE
中規模SPA向け基盤強化: API純化・認証状態改善・Error Boundary・環境変数検証・Abort/timeout対応

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { BrowserRouter } from "react-router-dom";
 
+import AppErrorBoundary from "./components/error/appErrorBoundary";
 import GlobalLoading from "./components/loading/globalLoading";
 import { GlobalStyle } from "./lib/style";
 import { Router } from "./router";
@@ -17,13 +18,15 @@ const App = () => {
   }, []);
 
   return (
-    <AppRootProvider>
-      <BrowserRouter>
-        <GlobalStyle />
-        <GlobalLoading />
-        <Router />
-      </BrowserRouter>
-    </AppRootProvider>
+    <AppErrorBoundary>
+      <AppRootProvider>
+        <BrowserRouter>
+          <GlobalStyle />
+          <GlobalLoading />
+          <Router />
+        </BrowserRouter>
+      </AppRootProvider>
+    </AppErrorBoundary>
   );
 };
 

--- a/src/components/error/appErrorBoundary.tsx
+++ b/src/components/error/appErrorBoundary.tsx
@@ -1,0 +1,36 @@
+import { Component } from "react";
+
+import type React from "react";
+
+type Props = { children: React.ReactNode };
+type State = { hasError: boolean };
+
+class AppErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  private readonly reset = () => {
+    this.setState({ hasError: false });
+  };
+
+  render() {
+    if (!this.state.hasError) return this.props.children;
+
+    return (
+      <main role="alert">
+        <h1>予期しないエラーが発生しました</h1>
+        <p>
+          操作をやり直してください。解決しない場合はページを再読み込みしてください。
+        </p>
+        <button onClick={this.reset} type="button">
+          もう一度試す
+        </button>
+      </main>
+    );
+  }
+}
+
+export default AppErrorBoundary;

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,45 @@
+const REQUIRED_VARIABLES = [
+  "VITE_APP_SITE_NAME",
+  "VITE_APP_BASE_URL",
+  "VITE_APP_DEFAULT_TITLE",
+  "VITE_APP_DEFAULT_DESCRIPTION",
+  "VITE_APP_DEFAULT_OG_IMAGE",
+  "VITE_APP_PUBLIC_API_BASE_URL",
+  "VITE_APP_AWS_COGNITO_IDENTITY_POOL_ID",
+  "VITE_APP_AWS_COGNITO_USER_POOL_ID",
+  "VITE_APP_AWS_COGNITO_CLIENT_ID",
+] as const;
+
+const URL_VARIABLES = [
+  "VITE_APP_BASE_URL",
+  "VITE_APP_PUBLIC_API_BASE_URL",
+] as const;
+
+type Environment = Record<string, string | boolean | undefined>;
+
+const isValidHttpUrl = (value: string) => {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+export const validateEnvironment = (environment: Environment) => {
+  const missing = REQUIRED_VARIABLES.filter(
+    (name) => !environment[name]?.toString().trim(),
+  );
+  const invalidUrls = URL_VARIABLES.filter((name) => {
+    const value = environment[name];
+    return typeof value === "string" && value !== "" && !isValidHttpUrl(value);
+  });
+  const problems = [
+    missing.length > 0 ? `未設定: ${missing.join(", ")}` : "",
+    invalidUrls.length > 0 ? `URL形式が不正: ${invalidUrls.join(", ")}` : "",
+  ].filter(Boolean);
+
+  if (problems.length > 0) {
+    throw new Error(`環境変数の検証に失敗しました（${problems.join(" / ")}）`);
+  }
+};

--- a/src/lib/types/_apiHelperType.ts
+++ b/src/lib/types/_apiHelperType.ts
@@ -16,8 +16,9 @@ export type RequestOptions<TRequest> = {
   apiPath: string;
   baseURL?: string;
   headers?: Record<string, string>;
-  isLoading?: boolean;
   method: Method;
   params?: Record<string, unknown>;
   requestData?: TRequest;
+  signal?: AbortSignal;
+  timeout?: number;
 };

--- a/src/lib/types/_authHelperType.ts
+++ b/src/lib/types/_authHelperType.ts
@@ -1,5 +1,19 @@
+export type AuthInitializationError = {
+  message: string;
+  name: string;
+};
+
+export type AuthState =
+  | { status: "anonymous" }
+  | { error: AuthInitializationError; status: "error" }
+  | { status: "authenticated" }
+  | { status: "checking" };
+
 export type AuthContextValue = {
+  authState: AuthState;
+  /** @deprecated Prefer authState.status. */
   isChecking: boolean;
+  /** @deprecated Prefer authState.status. */
   isSignedIn: boolean;
   refreshAuthState: () => void;
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,10 +2,13 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 
 import App from "./App.tsx";
+import { validateEnvironment } from "./config/env";
 
 /* -----------------------------------------------
  * main ファイル
  * ----------------------------------------------- */
+
+validateEnvironment(import.meta.env);
 
 const container = document.getElementById("root");
 

--- a/src/router/guards.tsx
+++ b/src/router/guards.tsx
@@ -10,20 +10,41 @@ type GuardProps = { children: React.ReactNode };
 
 const AuthChecking = () => <p>認証状態を確認しています...</p>;
 
+const AuthError: React.FC<{ onRetry: () => void }> = ({ onRetry }) => (
+  <div role="alert">
+    <p>認証状態を確認できませんでした。通信環境を確認してください。</p>
+    <button onClick={onRetry} type="button">
+      再試行
+    </button>
+  </div>
+);
+
 // 認証済みユーザーのみアクセス可とするガード処理
 const AuthGuard: React.FC<GuardProps> = ({ children }) => {
-  const { isChecking, isSignedIn } = useAuth(); // サインインフラグ
+  const { authState, refreshAuthState } = useAuth();
 
-  if (isChecking) return <AuthChecking />;
-  return isSignedIn ? children : <Navigate replace to="/auth/signin" />;
+  if (authState.status === "checking") return <AuthChecking />;
+  if (authState.status === "error")
+    return <AuthError onRetry={refreshAuthState} />;
+  return authState.status === "authenticated" ? (
+    children
+  ) : (
+    <Navigate replace to="/auth/signin" />
+  );
 };
 
 // 未認証ユーザーのみアクセス可とするガード処理
 const GuestGuard: React.FC<GuardProps> = ({ children }) => {
-  const { isChecking, isSignedIn } = useAuth(); // サインインフラグ
+  const { authState, refreshAuthState } = useAuth();
 
-  if (isChecking) return <AuthChecking />;
-  return isSignedIn ? <Navigate replace to="/auth/signout" /> : children;
+  if (authState.status === "checking") return <AuthChecking />;
+  if (authState.status === "error")
+    return <AuthError onRetry={refreshAuthState} />;
+  return authState.status === "authenticated" ? (
+    <Navigate replace to="/auth/signout" />
+  ) : (
+    children
+  );
 };
 
 /*

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -12,7 +12,7 @@ import { usePVTracking } from "../utils/gaHelper";
  * ----------------------------------------------- */
 
 export function Router() {
-  const { isChecking, isSignedIn } = useAuth(); // サインインフラグ
+  const { authState } = useAuth();
 
   usePVTracking(); // GA4 PV計測処理
 
@@ -52,12 +52,16 @@ export function Router() {
         <Route
           // ルート/auth 遷移時はサインイン状態に応じ SignOut/SignInページ へリダイレクト
           element={
-            isChecking ? (
+            authState.status === "checking" || authState.status === "error" ? (
               <p>認証状態を確認しています...</p>
             ) : (
               <Navigate
                 replace
-                to={isSignedIn ? "/auth/signout" : "/auth/signin"}
+                to={
+                  authState.status === "authenticated"
+                    ? "/auth/signout"
+                    : "/auth/signin"
+                }
               />
             )
           }

--- a/src/utils/apiHelper/client.ts
+++ b/src/utils/apiHelper/client.ts
@@ -1,12 +1,11 @@
 import { fetchAuthSession } from "aws-amplify/auth";
 import axios from "axios";
 
-import { loadingFlagDown, loadingFlagUp, store } from "../storeHelper";
-
 import type { ApiResult, RequestOptions } from "../../lib/types";
 import type { AxiosRequestConfig, Method } from "axios";
 
 const DEFAULT_BASE_URL = import.meta.env.VITE_APP_PUBLIC_API_BASE_URL ?? "";
+const DEFAULT_TIMEOUT = 10_000;
 
 /* -----------------------------------------------
  * APIリクエスト処理
@@ -46,12 +45,11 @@ export const request = async <TResponse = unknown, TRequest = unknown>(
     accessToken,
     baseURL = DEFAULT_BASE_URL,
     headers,
-    isLoading = true,
     params,
     requestData,
+    signal,
+    timeout = DEFAULT_TIMEOUT,
   } = options;
-
-  if (isLoading) store.dispatch(loadingFlagUp()); // ローディングフラグを上げる
 
   try {
     // リクエスト内容
@@ -60,6 +58,8 @@ export const request = async <TResponse = unknown, TRequest = unknown>(
       headers: await setHeaders(accessToken, headers), // リクエストヘッダー生成
       method,
       params,
+      signal,
+      timeout,
       url: `${baseURL}${apiPath}`,
     };
 
@@ -79,7 +79,5 @@ export const request = async <TResponse = unknown, TRequest = unknown>(
       };
     }
     throw error;
-  } finally {
-    if (isLoading) store.dispatch(loadingFlagDown()); // ローディングフラグを下げる
   }
 };

--- a/src/utils/apiHelper/modules/exampleApi.ts
+++ b/src/utils/apiHelper/modules/exampleApi.ts
@@ -15,13 +15,14 @@ export const testPostApi = <TRequest>(data: TRequest) => {
 };
 
 /*
- * export const postXXXXApi = (params, baseURL, headers, requestData, accessToken, isLoading) => {
+ * export const postXXXXApi = (params, baseURL, headers, requestData, accessToken) => {
  *  const options = {
  *    accessToken?, // アクセストークン
  *    baseURL?, // DEFAULT_BASE_URL を使わない際のベースURL
  *    headers?, // 追加ヘッダー情報を付与
- *    isLoading?, // ローディングフラグ制御
  *    params?, // クエリパラム
+ *    signal?, // リクエストキャンセル用のAbortSignal
+ *    timeout?, // タイムアウト（ミリ秒）
  *    requestData?, // リクエストデータ（リクエストボディ）
  *  };
  *  return request('POST', '/xxxx/xxxx', options);

--- a/src/utils/authHelper/authProvider.tsx
+++ b/src/utils/authHelper/authProvider.tsx
@@ -1,7 +1,11 @@
 import { getCurrentUser } from "aws-amplify/auth";
-import { createContext, useEffect, useMemo, useState } from "react";
+import { createContext, useEffect, useMemo, useRef, useState } from "react";
 
-import type { AuthContextValue } from "../../lib/types";
+import type {
+  AuthContextValue,
+  AuthInitializationError,
+  AuthState,
+} from "../../lib/types";
 import type React from "react";
 
 /* -----------------------------------------------
@@ -10,26 +14,46 @@ import type React from "react";
 
 export const AuthContext = createContext<AuthContextValue | null>(null);
 
-const getCurrentSignInFlag = async () => {
+const getErrorProperty = (error: unknown, property: "message" | "name") => {
+  if (!(error instanceof Error)) return "UnknownAuthError";
+  return error[property];
+};
+
+const isAnonymousError = (error: unknown) => {
+  const name = getErrorProperty(error, "name");
+  const message = getErrorProperty(error, "message");
+  return [name, message].some((value) =>
+    /NotAuthorized|Unauthenticated|UserUnAuthenticated/i.test(value),
+  );
+};
+
+const toInitializationError = (error: unknown): AuthInitializationError => ({
+  message: getErrorProperty(error, "message"),
+  name: getErrorProperty(error, "name"),
+});
+
+const getCurrentAuthState = async (): Promise<AuthState> => {
   try {
     await getCurrentUser();
-    return true;
-  } catch {
-    return false;
+    return { status: "authenticated" };
+  } catch (error) {
+    if (isAnonymousError(error)) return { status: "anonymous" };
+    return { error: toInitializationError(error), status: "error" };
   }
 };
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const [isSignedIn, setIsSignedIn] = useState<boolean>(false);
-  const [isChecking, setIsChecking] = useState<boolean>(true);
+  const [authState, setAuthState] = useState<AuthState>({ status: "checking" });
+  const refreshSequence = useRef(0);
 
   const refreshAuthState = () => {
-    setIsChecking(true);
-    void getCurrentSignInFlag()
-      .then(setIsSignedIn)
-      .finally(() => setIsChecking(false));
+    const sequence = ++refreshSequence.current;
+    setAuthState({ status: "checking" });
+    void getCurrentAuthState().then((nextState) => {
+      if (sequence === refreshSequence.current) setAuthState(nextState);
+    });
   };
 
   useEffect(() => {
@@ -37,8 +61,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   }, []);
 
   const value = useMemo(
-    () => ({ isChecking, isSignedIn, refreshAuthState }),
-    [isChecking, isSignedIn],
+    () => ({
+      authState,
+      isChecking: authState.status === "checking",
+      isSignedIn: authState.status === "authenticated",
+      refreshAuthState,
+    }),
+    [authState],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,18 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_APP_AWS_COGNITO_CLIENT_ID: string;
+  readonly VITE_APP_AWS_COGNITO_IDENTITY_POOL_ID: string;
+  readonly VITE_APP_AWS_COGNITO_USER_POOL_ID: string;
+  readonly VITE_APP_BASE_URL: string;
+  readonly VITE_APP_DEFAULT_DESCRIPTION: string;
+  readonly VITE_APP_DEFAULT_OG_IMAGE: string;
+  readonly VITE_APP_DEFAULT_TITLE: string;
+  readonly VITE_APP_GA_MEASUREMENT_ID?: string;
+  readonly VITE_APP_PUBLIC_API_BASE_URL: string;
+  readonly VITE_APP_SITE_NAME: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/tests/components/error/appErrorBoundary.test.tsx
+++ b/tests/components/error/appErrorBoundary.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import AppErrorBoundary from "../../../src/components/error/appErrorBoundary";
+
+const BrokenComponent = () => {
+  throw new Error("render failed");
+};
+
+describe("AppErrorBoundary", () => {
+  it("子コンポーネントの描画エラー時に復旧画面を表示する", () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    render(
+      <AppErrorBoundary>
+        <BrokenComponent />
+      </AppErrorBoundary>,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "予期しないエラーが発生しました" }),
+    ).toBeVisible();
+    expect(screen.getByRole("button", { name: "もう一度試す" })).toBeVisible();
+  });
+});

--- a/tests/config/env.test.ts
+++ b/tests/config/env.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { validateEnvironment } from "../../src/config/env";
+
+const validEnvironment = {
+  VITE_APP_AWS_COGNITO_CLIENT_ID: "client-id",
+  VITE_APP_AWS_COGNITO_IDENTITY_POOL_ID: "identity-pool-id",
+  VITE_APP_AWS_COGNITO_USER_POOL_ID: "user-pool-id",
+  VITE_APP_BASE_URL: "https://example.com",
+  VITE_APP_DEFAULT_DESCRIPTION: "description",
+  VITE_APP_DEFAULT_OG_IMAGE: "/ogp.jpg",
+  VITE_APP_DEFAULT_TITLE: "title",
+  VITE_APP_PUBLIC_API_BASE_URL: "https://api.example.com",
+  VITE_APP_SITE_NAME: "site",
+};
+
+describe("validateEnvironment", () => {
+  it("必要な環境変数とURLが正しければ成功する", () => {
+    expect(() => validateEnvironment(validEnvironment)).not.toThrow();
+  });
+
+  it("不足している環境変数名を含むエラーを送出する", () => {
+    expect(() =>
+      validateEnvironment({ ...validEnvironment, VITE_APP_SITE_NAME: "" }),
+    ).toThrow("VITE_APP_SITE_NAME");
+  });
+
+  it("HTTP以外のURLを拒否する", () => {
+    expect(() =>
+      validateEnvironment({
+        ...validEnvironment,
+        VITE_APP_BASE_URL: "ftp://example.com",
+      }),
+    ).toThrow("URL形式が不正");
+  });
+});

--- a/tests/features/pageTestUtils.tsx
+++ b/tests/features/pageTestUtils.tsx
@@ -12,6 +12,7 @@ export const renderPage = (page: ReactElement) =>
     <Provider store={store}>
       <AuthContext.Provider
         value={{
+          authState: { status: "anonymous" },
           isChecking: false,
           isSignedIn: false,
           refreshAuthState: () => undefined,

--- a/tests/router/routerGuards.test.tsx
+++ b/tests/router/routerGuards.test.tsx
@@ -21,11 +21,16 @@ const createRoute = (access: AppRoute["access"]): AppRoute => ({
 
 const renderGuard = (
   access: AppRoute["access"],
-  authState: Pick<AuthContextValue, "isChecking" | "isSignedIn">,
+  authState: AuthContextValue["authState"],
 ) =>
   render(
     <AuthContext.Provider
-      value={{ ...authState, refreshAuthState: () => undefined }}
+      value={{
+        authState,
+        isChecking: authState.status === "checking",
+        isSignedIn: authState.status === "authenticated",
+        refreshAuthState: () => undefined,
+      }}
     >
       <MemoryRouter initialEntries={["/target"]}>
         <Location />
@@ -42,21 +47,21 @@ const renderGuard = (
 
 describe("router guards", () => {
   it("未認証でauthページへアクセスするとサインインへリダイレクトする", async () => {
-    renderGuard("auth", { isChecking: false, isSignedIn: false });
+    renderGuard("auth", { status: "anonymous" });
 
     expect(await screen.findByText("Sign in destination")).toBeVisible();
     expect(screen.getByTestId("location")).toHaveTextContent("/auth/signin");
   });
 
   it("認証済みでguestページへアクセスするとサインアウトへリダイレクトする", async () => {
-    renderGuard("guest", { isChecking: false, isSignedIn: true });
+    renderGuard("guest", { status: "authenticated" });
 
     expect(await screen.findByText("Sign out destination")).toBeVisible();
     expect(screen.getByTestId("location")).toHaveTextContent("/auth/signout");
   });
 
   it("認証状態のchecking中はページやリダイレクト先を表示しない", () => {
-    renderGuard("auth", { isChecking: true, isSignedIn: false });
+    renderGuard("auth", { status: "checking" });
 
     expect(screen.getByText("認証状態を確認しています...")).toBeVisible();
     expect(screen.queryByText("Protected content")).toBeNull();
@@ -64,7 +69,7 @@ describe("router guards", () => {
   });
 
   it("ガード条件を満たす場合はリダイレクトせず対象ページを表示する", async () => {
-    renderGuard("auth", { isChecking: false, isSignedIn: true });
+    renderGuard("auth", { status: "authenticated" });
 
     expect(
       await screen.findByRole("heading", { name: "Protected content" }),

--- a/tests/utils/apiClient.test.ts
+++ b/tests/utils/apiClient.test.ts
@@ -3,7 +3,6 @@ import axios from "axios";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { request } from "../../src/utils/apiHelper/client";
-import { store } from "../../src/utils/storeHelper";
 
 vi.mock("aws-amplify/auth", () => ({ fetchAuthSession: vi.fn() }));
 vi.mock("axios", () => ({
@@ -18,14 +17,6 @@ const mockedAxiosRequest = vi.mocked(axios.request);
 const mockedIsAxiosError = vi.mocked(axios.isAxiosError);
 const baseURL = "https://example.com";
 const jsonContentType = "application/json";
-
-const createDeferred = <T>() => {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((promiseResolve) => {
-    resolve = promiseResolve;
-  });
-  return { promise, resolve };
-};
 
 describe("api client", () => {
   beforeEach(() => {
@@ -59,10 +50,11 @@ describe("api client", () => {
       },
       method: "POST",
       params: { preview: true },
+      signal: undefined,
+      timeout: 10_000,
       url: "https://example.com/articles",
     });
     expect(result).toEqual({ ok: true, response });
-    expect(store.getState().loading.count).toBe(0);
   });
 
   it("トークン未指定時は認証セッションを確認する", async () => {
@@ -70,7 +62,6 @@ describe("api client", () => {
 
     await request("GET", "/profile", {
       baseURL,
-      isLoading: false,
     });
 
     expect(mockedFetchAuthSession).toHaveBeenCalledOnce();
@@ -82,10 +73,9 @@ describe("api client", () => {
         },
       }),
     );
-    expect(store.getState().loading.count).toBe(0);
   });
 
-  it("AxiosエラーをApiErrorに変換しローディングを解除する", async () => {
+  it("AxiosエラーをApiErrorに変換する", async () => {
     const error = {
       message: "Request failed with status code 422",
       response: { data: { reason: "invalid" }, status: 422 },
@@ -105,10 +95,9 @@ describe("api client", () => {
       },
       ok: false,
     });
-    expect(store.getState().loading.count).toBe(0);
   });
 
-  it("Axios以外のエラーは再送出しローディングを解除する", async () => {
+  it("Axios以外のエラーは再送出する", async () => {
     const error = new Error("unexpected error");
     mockedAxiosRequest.mockRejectedValue(error);
     mockedIsAxiosError.mockReturnValue(false);
@@ -116,7 +105,6 @@ describe("api client", () => {
     await expect(request("GET", "/articles", { baseURL })).rejects.toThrow(
       "unexpected error",
     );
-    expect(store.getState().loading.count).toBe(0);
   });
 
   it("401レスポンスをステータスとレスポンスデータを含むApiErrorに変換する", async () => {
@@ -135,10 +123,9 @@ describe("api client", () => {
       },
       ok: false,
     });
-    expect(store.getState().loading.count).toBe(0);
   });
 
-  it("認証セッションの取得失敗を再送出しローディングを解除する", async () => {
+  it("認証セッションの取得失敗を再送出する", async () => {
     mockedFetchAuthSession.mockRejectedValue(new Error("session unavailable"));
     mockedIsAxiosError.mockReturnValue(false);
 
@@ -146,27 +133,21 @@ describe("api client", () => {
       "session unavailable",
     );
     expect(mockedAxiosRequest).not.toHaveBeenCalled();
-    expect(store.getState().loading.count).toBe(0);
   });
 
-  it("同時リクエストが完了するたびにloading countを減らす", async () => {
-    const firstResponse = createDeferred<{ data: string }>();
-    const secondResponse = createDeferred<{ data: string }>();
-    mockedAxiosRequest
-      .mockImplementationOnce(() => firstResponse.promise)
-      .mockImplementationOnce(() => secondResponse.promise);
+  it("タイムアウトとキャンセルシグナルをHTTP層へ渡す", async () => {
+    const controller = new AbortController();
+    mockedAxiosRequest.mockResolvedValue({ data: null });
 
-    const firstRequest = request("GET", "/first", { baseURL });
-    const secondRequest = request("GET", "/second", { baseURL });
+    await request("GET", "/slow", {
+      accessToken: "token",
+      baseURL,
+      signal: controller.signal,
+      timeout: 2_000,
+    });
 
-    expect(store.getState().loading.count).toBe(2);
-
-    firstResponse.resolve({ data: "first" });
-    await firstRequest;
-    expect(store.getState().loading.count).toBe(1);
-
-    secondResponse.resolve({ data: "second" });
-    await secondRequest;
-    expect(store.getState().loading.count).toBe(0);
+    expect(mockedAxiosRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ signal: controller.signal, timeout: 2_000 }),
+    );
   });
 });

--- a/tests/utils/authProvider.test.tsx
+++ b/tests/utils/authProvider.test.tsx
@@ -16,11 +16,7 @@ const AuthState = () => {
   const auth = useContext(AuthContext);
   if (!auth) throw new Error("AuthContext is not available");
 
-  return (
-    <p>
-      {auth.isChecking ? "checking" : auth.isSignedIn ? "signed-in" : "guest"}
-    </p>
-  );
+  return <p>{auth.authState.status}</p>;
 };
 
 describe("AuthProvider", () => {
@@ -51,7 +47,7 @@ describe("AuthProvider", () => {
       </AuthProvider>,
     );
 
-    expect(await screen.findByText("signed-in")).toBeVisible();
+    expect(await screen.findByText("authenticated")).toBeVisible();
     expect(mockedGetCurrentUser).toHaveBeenCalledOnce();
   });
 
@@ -66,10 +62,10 @@ describe("AuthProvider", () => {
       </AuthProvider>,
     );
 
-    expect(await screen.findByText("guest")).toBeVisible();
+    expect(await screen.findByText("anonymous")).toBeVisible();
   });
 
-  it("認証状態の確認に失敗しても初期化を完了してguest状態にする", async () => {
+  it("認証状態の確認障害を未認証と区別して公開する", async () => {
     mockedGetCurrentUser.mockRejectedValue(new Error("network failure"));
 
     render(
@@ -79,6 +75,6 @@ describe("AuthProvider", () => {
     );
 
     await waitFor(() => expect(screen.queryByText("checking")).toBeNull());
-    expect(screen.getByText("guest")).toBeVisible();
+    expect(screen.getByText("error")).toBeVisible();
   });
 });


### PR DESCRIPTION
### Motivation

- 中規模化のロードマップに沿って、フォルダ再編を伴わない実務的な基盤改善として `API client の純化`、`認証エラー状態の改善`、`Error Boundary`、`環境変数検証`、および HTTP の `timeout` / `AbortSignal` 対応を実装しました（監視・E2E は今回除外）。
- 既存の可読性や設計を崩さずに、HTTP 層と認証初期化の責務を明確化して運用時の誤判定やハングを減らすことを目的としています。

### Description

- `src/utils/apiHelper/client.ts`: API クライアントから Redux のグローバルローディング依存を除去し、`AbortSignal` と `timeout`（既定 10_000ms）を引数として渡せるようにして HTTP 層の責務に限定しました。`RequestOptions` 型に `signal`/`timeout` を追加しました。 
- `src/utils/authHelper/authProvider.tsx` / `src/lib/types/_authHelperType.ts`: 認証状態を `AuthState`（`checking` / `authenticated` / `anonymous` / `error`）として明確化し、初期化エラーを区別する変換ロジックと連続呼び出し時の競合制御（シーケンス番号）を導入しました。既存の `isChecking` / `isSignedIn` は `authState` ベースで提供します。 
- `src/router/guards.tsx` / `src/router/index.tsx`: ガードを `authState` に対応させ、初期化時のエラーは再試行 UI を表示する `AuthError` を返すよう変更しました。ルートのリダイレクト判定も `authState` を参照するよう更新しています。 
- `src/components/error/appErrorBoundary.tsx` / `src/App.tsx`: ルート用の Error Boundary を追加し、`App` にラップして子コンポーネントの描画例外をユーザー向けの復旧画面に切り替えられるようにしました。 
- `src/config/env.ts` / `src/main.tsx` / `src/vite-env.d.ts`: 必須の Vite 環境変数を検証する `validateEnvironment` を追加して、レンダリング開始前に未設定や不正な URL を検出するようにしました。型定義も強化しています。 
- テスト追加・更新: `tests/utils/apiClient.test.ts` にタイムアウト/キャンセルの検証を追加し、`tests/utils/authProvider.test.tsx` を `authState` ベースへ更新、`tests/components/error/appErrorBoundary.test.tsx` と `tests/config/env.test.ts` を追加して各変更をカバーしています。 

### Testing

- 自動テスト: `yarn test` を実行し、テストファイル 19 件・テスト 39 件が全て成功しました（すべてのテストがパス）。
- 品質ゲート: `yarn checker` / Prettier のチェックを実行して合格しました。
- ビルド: `yarn build` によるプロダクションビルドが正常に完了しました。

（注）監視（Sentry 等）と E2E は指定どおり今回の対応から除外しています。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7bff30c5608324a8b46b79447a19b1)